### PR TITLE
Add Safari and Opera support for cookie detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Supported browsers:
 - Chromium
 - Edge
 - Firefox
+- Opera
+- Safari
 
 Supported platforms:
 - macOS

--- a/internal/cookies/cookies.go
+++ b/internal/cookies/cookies.go
@@ -11,11 +11,13 @@ import (
 	_ "github.com/browserutils/kooky/browser/chromium"
 	_ "github.com/browserutils/kooky/browser/edge"
 	_ "github.com/browserutils/kooky/browser/firefox"
+	_ "github.com/browserutils/kooky/browser/opera"
+	_ "github.com/browserutils/kooky/browser/safari"
 )
 
 // GetGitHubSession returns the user_session cookie for github.com.
-// It searches Chrome, Brave, Edge, Chromium, and Firefox (via kooky's registered
-// finders), returning the cookie from the first browser that has one.
+// It searches Chrome, Brave, Edge, Chromium, Firefox, Opera, and Safari (via kooky's
+// registered finders), returning the cookie from the first browser that has one.
 func GetGitHubSession() (*http.Cookie, error) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary

- Add blank imports for `github.com/browserutils/kooky/browser/safari` and `github.com/browserutils/kooky/browser/opera` so Safari and Opera users can authenticate with gh-image
- No new dependencies — both browsers' cookie readers only use packages already in the dependency tree
- Same pattern as the Firefox PR (#9)

## Test plan

- [x] `go build` succeeds
- [x] `go test ./...` passes
- [x] Safari and Opera `init` symbols present in binary
- [x] End-to-end upload test passes