### PR TITLE
v1.0.0 release prep: docs rewrite, CI, dependabot, --version, SECURITY.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: stable
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
       - run: go vet ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: go vet ./...
+      - run: go test -race -cover ./...
+      - run: go build ./...

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w
+      - -s -w -X main.version={{.Version}}
     goos:
       - darwin
       - linux

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 drogers0
+Copyright (c) 2025-2026 drogers0
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,201 +1,196 @@
-# gh-image
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/92463e67-b897-4212-91b4-a4f9b80ec4d4" alt="gh-image banner" width="640">
+</p>
 
-![banner](https://github.com/user-attachments/assets/92463e67-b897-4212-91b4-a4f9b80ec4d4)
+<p align="center">
+  <em>Drop images into GitHub issues, PRs, and READMEs, straight from the command line.</em>
+</p>
 
-A `gh` CLI extension that uploads images to GitHub from the command line.
+<p align="center">
+  <a href="https://github.com/drogers0/gh-image/releases/latest"><img src="https://img.shields.io/github/v/release/drogers0/gh-image?color=blue" alt="Latest release"></a>
+  <a href="https://github.com/drogers0/gh-image/stargazers"><img src="https://img.shields.io/github/stars/drogers0/gh-image?style=flat&color=yellow" alt="GitHub stars"></a>
+  <a href="https://github.com/drogers0/gh-image/releases"><img src="https://img.shields.io/github/downloads/drogers0/gh-image/total?color=green" alt="Total downloads"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/drogers0/gh-image?color=lightgrey" alt="License: MIT"></a>
+  <a href="https://goreportcard.com/report/github.com/drogers0/gh-image"><img src="https://goreportcard.com/badge/github.com/drogers0/gh-image" alt="Go Report Card"></a>
+</p>
 
-GitHub has no public API for image uploads — the web UI uses an internal endpoint that produces URLs scoped to a repository's visibility. This tool replicates that flow, so images on private repos stay private.
+---
 
-## Usage
+GitHub has no public API for image uploads. The web UI uses an internal endpoint that produces `user-attachments` URLs whose visibility is scoped to the repository they were uploaded to. `gh-image` replicates that flow as a `gh` CLI extension, so you can drop a screenshot into a bug report, README, or Slack thread without leaving the terminal — and images on private repos stay private.
 
-```bash
-# Upload an image and get the markdown (infers repo from current git workspace)
-gh image screenshot.png
-
-# Upload multiple images
-gh image img1.png img2.png
-
-# Explicit repo (when not in a git workspace or targeting a different repo)
-gh image screenshot.png --repo owner/repo
+```console
+$ gh image screenshot.png
+![screenshot.png](https://github.com/user-attachments/assets/88f4599a-…-bc24)
 ```
 
-Output:
-```
-![screenshot](https://github.com/user-attachments/assets/<uuid>)
-```
-
-### Example: Upload an image and attach it to a GitHub issue
-
-```bash
-# Upload the image
-gh image screenshot.png --repo owner/repo
-# Output: ![screenshot.png](https://github.com/user-attachments/assets/88f4599a-...)
-
-# Use the output in a new issue
-gh issue create --repo owner/repo \
-  --title "Bug report" \
-  --body "Here's what I see:
-
-![screenshot.png](https://github.com/user-attachments/assets/88f4599a-...)
-"
-```
-
-## Install
+## Installation
 
 ```bash
 gh extension install drogers0/gh-image
 ```
 
-## How It Works
+That's it. The [`gh` CLI](https://cli.github.com) auto-detects your platform and downloads the prebuilt binary. Pre-built releases ship for **macOS** (arm64, amd64), **Linux** (amd64, arm64), and **Windows** (amd64).
 
-1. Reads your GitHub session cookie from your browser's local cookie store (encrypted cookie decryption handled automatically)
-2. Uploads the image through GitHub's internal asset upload flow (the same one the web UI uses)
-3. Prints a markdown image reference to stdout
+<details>
+<summary>Build from source</summary>
 
-The upload produces `https://github.com/user-attachments/assets/<uuid>` URLs — the same format as drag-and-drop uploads in the browser. Images inherit the repository's visibility: private repo images require authentication to view.
+```bash
+git clone https://github.com/drogers0/gh-image
+cd gh-image
+go build -o gh-image
+gh extension install .
+```
 
-See [documentation/github-image-upload-flow.md](documentation/github-image-upload-flow.md) for the full reverse-engineered upload protocol.
+Requires Go 1.26+.
+
+</details>
+
+## Usage
+
+```bash
+# Upload an image (infers repo from the current git workspace)
+gh image screenshot.png
+
+# Upload multiple images at once
+gh image hero.png diagram.png chart.png
+
+# Target a specific repository
+gh image screenshot.png --repo owner/repo
+```
+
+Each successful upload prints a ready-to-paste markdown reference on its own line:
+
+```
+![hero.png](https://github.com/user-attachments/assets/…)
+![diagram.png](https://github.com/user-attachments/assets/…)
+```
+
+If any upload fails, the error is printed to stderr and the process exits non-zero — other images in the batch still upload.
+
+### Pipe directly into an issue, PR, or comment
+
+From inside the repo's working directory, both `gh image` and `gh issue create` infer the target repository automatically:
+
+```bash
+gh issue create \
+  --title "Login button stuck in loading state" \
+  --body "Repro on staging:
+
+$(gh image bug.png)
+
+Happens consistently after the third click."
+```
 
 ## Authentication
 
-No tokens or OAuth setup required. The tool reads your `user_session` cookie directly from your browser's cookie database on disk. On macOS, a Keychain prompt may appear on first use to authorize access to the browser's encryption key.
+`gh-image` authenticates with your existing GitHub session — **no tokens to provision, no OAuth scopes to configure** for everyday local use. The tool reads the `user_session` cookie from your browser's encrypted cookie store.
 
-Supported browsers:
-- Chrome
-- Brave
-- Chromium
-- Edge
-- Firefox
-- Opera
-- Safari
+**Supported browsers:** Chrome · Brave · Chromium · Edge · Firefox · Opera · Safari
 
-Supported platforms:
-- macOS
-- Linux
-- Windows
+**Supported platforms:** macOS · Linux · Windows
 
-## Session Token
+On macOS, a Keychain prompt may appear on first use to authorize access to your browser's cookie encryption key. Click **Always Allow** to skip future prompts.
 
-The tool supports providing your own session token instead of reading from the browser. This enables use in environments where browser cookies are unavailable (such as CI).
+### Session token override
 
-> **Warning:** `user_session` cookies grant full account access — they are not
-> scoped like personal access tokens. Treat them with the same care as a password.
-> Rotate promptly if leaked.
+For CI, headless environments, or shared machines, you can supply the session token explicitly. Resolution order (first match wins):
 
-**Token resolution order (highest priority first):**
-
-1. `--token <value>` flag
-2. `GH_SESSION_TOKEN` environment variable
-3. Browser cookie extraction (default)
+| Priority | Source | When to use |
+|---|---|---|
+| 1 | `--token <value>` flag | One-off invocations |
+| 2 | `GH_SESSION_TOKEN` env var | CI/CD, shared machines |
+| 3 | Browser cookie store | Local interactive use (default) |
 
 ```bash
-# Use a token via flag
+# Flag (visible in process listings like `ps aux` — avoid on shared machines)
 gh image --token "$MY_TOKEN" screenshot.png --repo owner/repo
 
-# Use a token via environment variable (preferred on shared machines)
+# Environment variable (preferred — not visible to `ps aux`)
 GH_SESSION_TOKEN="$MY_TOKEN" gh image screenshot.png --repo owner/repo
 ```
 
-> **Security note:** `--token` values are visible in process listings (`ps aux`).
-> Use the `GH_SESSION_TOKEN` environment variable on shared machines.
+> [!WARNING]
+> `user_session` cookies grant **full account access** — they are not scoped like personal access tokens. Treat them with the same care as a password. If leaked, **[sign out of GitHub](https://github.com/logout)** on the machine that holds the session; if you are not on that machine, revoke it through [Settings → Sessions](https://github.com/settings/sessions), or [change your password](https://github.com/settings/security) (which kills every session in one action).
 
 
-## Token Utilities
+## CI / CD
 
-### `extract-token`
+`gh-image` runs unattended in GitHub Actions when given a session token via `GH_SESSION_TOKEN`.
 
-Extracts your session token from the browser and prints it to stdout. Useful for storing your token as a CI secret.
+> [!CAUTION]
+> **Use a dedicated bot account on shared repos.** GitHub hides secret values in the UI and masks log emissions, but a determined collaborator with write access can craft a workflow that exfiltrates the value through channels masking doesn't cover. Storing your *personal* `user_session` means such a leak compromises your account; a bot account scopes the blast radius to that bot. Decide whose token to extract in step 1 below accordingly.
 
-```bash
-# Extract and print token
-gh image extract-token
+**Setup**
 
-# Store in a variable
-TOKEN=$(gh image extract-token)
-```
-
-### `check-token`
-
-Verifies that a session token is valid and, on a best-effort basis, prints the authenticated GitHub username to stdout. Exit code 0 means valid, exit code 1 means invalid or an error occurred. Username output may be empty even when the token is valid (for example, if the `<meta name="user-login">` tag is missing or cannot be parsed), so rely on the exit code for validity checks.
-
-```bash
-# Check token from flag
-gh image check-token --token "$MY_TOKEN"
-
-# Check token from environment variable
-GH_SESSION_TOKEN="$MY_TOKEN" gh image check-token
-
-# Check token from browser (default)
-gh image check-token
-
-# Capture username in a script
-USERNAME=$(gh image check-token --token "$MY_TOKEN")
-```
-
-## CI/CD Usage
-
-> **Note:** `user_session` cookies are real user login sessions, not scoped automation credentials. They expire when GitHub invalidates the session. Use a pre-push hook or periodic job to validate the token (see `check-token`) and rotate it when needed.
-
-### Setup
-
-1. Extract your token locally:
-   ```bash
-   gh image extract-token
-   ```
-2. Add the output as a repository secret named `GH_SESSION_TOKEN` in your GitHub repository settings.
-
-### Example GitHub Actions workflow
+1. Run `gh image extract-token` locally to capture the token (token → stdout, status → stderr), then run `gh image check-token --token <token>` to confirm it authenticates as the intended user (username → stdout on success, exit code `0` = valid).
+2. Create a GitHub environment (Settings → Environments → New environment), e.g. `gh-image`, and restrict deployment branches to a trusted set (e.g. `main` only).
+3. Add the token as an **environment secret** named `GH_SESSION_TOKEN` on that environment.
 
 ```yaml
-- name: Upload screenshots
-  env:
-    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}         # Required for gh CLI auth
-    GH_SESSION_TOKEN: ${{ secrets.GH_SESSION_TOKEN }} # GitHub session token
-  run: |
-    gh extension install drogers0/gh-image
-    gh image --repo owner/repo screenshot.png
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    environment: gh-image                                # binds this job to the scoped environment
+    steps:
+      - name: Upload screenshots
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}              # for gh CLI auth
+          GH_SESSION_TOKEN: ${{ secrets.GH_SESSION_TOKEN }}  # for the upload itself
+        run: |
+          gh extension install drogers0/gh-image
+          gh image check-token                                # optional: fail fast if the session expired
+          gh image screenshot.png --repo ${{ github.repository }}
 ```
 
-> **Note:** `gh` CLI must be authenticated (via `GH_TOKEN` or equivalent) for
-> extension installation and repository ID lookup. `GH_SESSION_TOKEN` is the
-> session token used for the image upload itself.
+> [!NOTE]
+> `user_session` cookies expire when GitHub invalidates the session. A scheduled `check-token` job is the cleanest way to detect expiry before it breaks a real run.
 
-### Validate token before upload
+## How it works
 
-```yaml
-- name: Validate session token
-  env:
-    GH_SESSION_TOKEN: ${{ secrets.GH_SESSION_TOKEN }}
-  run: gh image check-token
+1. Resolves a `user_session` cookie from the configured source (flag → env → browser).
+2. Fetches the target repository's page to obtain an `uploadToken` from the embedded JS payload.
+3. Requests an S3 upload policy from `/upload/policies/assets`.
+4. Uploads the file directly to S3 using the presigned form fields.
+5. Calls back to GitHub to finalize the asset.
+6. Prints `![name](url)` to stdout.
 
-- name: Upload screenshots
-  env:
-    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    GH_SESSION_TOKEN: ${{ secrets.GH_SESSION_TOKEN }}
-  run: |
-    gh extension install drogers0/gh-image
-    gh image --repo owner/repo screenshot.png
-```
+The final URL is the standard `https://github.com/user-attachments/assets/<uuid>` format — visibility inherits from the target repository, so a private-repo upload requires authentication to view.
 
-### Cache extension for faster CI runs
-
-```yaml
-- name: Cache gh extensions
-  uses: actions/cache@v4
-  with:
-    path: ~/.local/share/gh/extensions
-    key: gh-extensions-${{ runner.os }}
-```
+For the full architecture, see **[documentation/architecture.md](documentation/architecture.md)**. For the reverse-engineered upload protocol, see **[documentation/github-image-upload-flow.md](documentation/github-image-upload-flow.md)**.
 
 ## Requirements
 
-- A supported browser with an active GitHub session (for local use)
-- Write access to the target repository
-- For CI: a valid `GH_SESSION_TOKEN` secret (see [CI/CD Usage](#cicd-usage))
+- A supported browser with an active GitHub session — or a `GH_SESSION_TOKEN` for CI.
+- Write access to the target repository (uploads require it).
+- A target repository — pass `--repo owner/repo`, or run from a git workspace whose `origin` remote is on GitHub.
+- The `gh` CLI must be installed and authenticated (used for repository ID lookup).
 
 ## Limitations
 
-- This tool uses an undocumented GitHub internal API that could change without notice.
-- The `uploadToken` required for uploads is only available to users with write access to the target repository.
-- Either `--repo` must be provided or the tool must be run from within a git workspace with a GitHub remote.
-- Session tokens are not scoped credentials — they expire with the browser session and should be rotated periodically.
+- Uses an **undocumented** internal GitHub API that may change without notice.
+- `uploadToken` is only issued to users with write access on the target repository.
+- Session cookies are not scoped credentials; they expire when GitHub invalidates the session.
+
+## Contributing
+
+Issues and pull requests are welcome. For bug reports, please include:
+
+- Your OS and browser
+- The exact `gh image` invocation
+- The error output (with any session token values redacted)
+
+Before opening a PR, run `go test ./...` and `go vet ./...`.
+
+## Support
+
+If `gh-image` saves you a few drag-and-drops, a ⭐ helps others find it:
+
+```bash
+gh api --method PUT user/starred/drogers0/gh-image
+```
+
+(or just click the star at the [top of this page](https://github.com/drogers0/gh-image))
+
+## License
+
+[MIT](LICENSE) © 2025-2026 drogers0

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Happens consistently after the third click."
 On macOS, a Keychain prompt may appear on first use to authorize access to your browser's cookie encryption key. Click **Always Allow** to skip future prompts.
 
 > [!NOTE]
-> **Windows + Chrome 127+:** Some versions of Chrome on Windows are not yet supported by the underlying cookie library.
+> **Windows + Chrome 127+:** Some versions of Chrome on Windows are not yet supported by the underlying cookie library. Use another browser or [investigate potential workarounds](https://github.com/drogers0/gh-image/issues/4).
 
 ### Session token override
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Happens consistently after the third click."
 
 On macOS, a Keychain prompt may appear on first use to authorize access to your browser's cookie encryption key. Click **Always Allow** to skip future prompts.
 
+> [!NOTE]
+> **Windows + Chrome 127+:** Some versions of Chrome on Windows are not yet supported by the underlying cookie library.
+
 ### Session token override
 
 For CI, headless environments, or shared machines, you can supply the session token explicitly. Resolution order (first match wins):
@@ -118,7 +121,7 @@ GH_SESSION_TOKEN="$MY_TOKEN" gh image screenshot.png --repo owner/repo
 `gh-image` runs unattended in GitHub Actions when given a session token via `GH_SESSION_TOKEN`.
 
 > [!CAUTION]
-> **Use a dedicated bot account on shared repos.** GitHub hides secret values in the UI and masks log emissions, but a determined collaborator with write access can craft a workflow that exfiltrates the value through channels masking doesn't cover. Storing your *personal* `user_session` means such a leak compromises your account; a bot account scopes the blast radius to that bot. Decide whose token to extract in step 1 below accordingly.
+> **Use a dedicated bot account for CI/CD on shared repos.** GitHub hides secret values in the UI and masks log emissions, but a determined collaborator with write access can craft a workflow that exfiltrates the value through channels masking doesn't cover. Storing your *personal* `user_session` means such a leak compromises your account; a bot account scopes the blast radius to that bot. Decide whose token to extract in step 1 below accordingly.
 
 **Setup**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## What this tool handles
+
+`gh-image` reads your GitHub `user_session` cookie from your browser's encrypted cookie store (or from an explicit token source) and uses it to authenticate against GitHub's internal image upload API.
+
+The cookie grants **full account access** — equivalent to your GitHub password, and not scoped like a personal access token. See the [Authentication](README.md#authentication) section of the README for full details on how the cookie is sourced and used.
+
+## Reporting a vulnerability
+
+If you've found a security issue in `gh-image`, please report it **privately** rather than opening a public issue.
+
+Use GitHub's [private vulnerability reporting](https://github.com/drogers0/gh-image/security/advisories/new) to submit the report.
+
+Please include:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce
+- Affected version(s)
+- Any proof-of-concept code, if applicable
+
+
+## If your session token has been leaked
+
+See the warning callout in the README's [Session token override](README.md#session-token-override) section for the recommended remediation flow (sign out → revoke session → change password).
+
+## Supported versions
+
+Security fixes are applied to the latest release only.
+
+| Version | Supported |
+|---|---|
+| Latest release | ✅ |
+| Older releases | ❌ — please upgrade |

--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -197,53 +197,35 @@ Responsibilities:
 
 ## Data Flow
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│  User: gh image screenshot.png another.png --repo o/r       │
-└──────────────────────────┬──────────────────────────────────┘
-                           │
-                           ▼
-                ┌──────────────────────┐
-                │  Resolve Session     │
-                │  flag > env > browser│
-                │  (kooky for browser) │
-                └──────────┬───────────┘
-                           │ user_session
-                           ▼
-                ┌──────────────────────┐
-                │  For each image:     │
-                │                      │
-                │  Fetch uploadToken   │
-                │  GET /repo page      │
-                └──────────┬───────────┘
-                           │ uploadToken
-                           ▼
-                ┌──────────────────────┐
-                │  Request Policy      │
-                │  POST /upload/       │
-                │  policies/assets     │
-                └──────────┬───────────┘
-                           │ S3 presigned form
-                           │ asset_upload_authenticity_token
-                           ▼
-                ┌──────────────────────┐
-                │  Upload to S3        │
-                │  POST policy.upload_ │
-                │  url (no GitHub auth)│
-                └──────────┬───────────┘
-                           │ 200 / 201 / 204
-                           ▼
-                ┌──────────────────────┐
-                │  Finalize            │
-                │  PUT /upload/        │
-                │  assets/{id}         │
-                └───────────┬──────────┘
-                           │ asset href URL
-                           ▼
-                ┌──────────────────────┐
-                │  Print markdown      │
-                │  to stdout           │
-                └──────────────────────┘
+```mermaid
+flowchart TD
+    Start(["<b>User:</b> gh image screenshot.png another.png --repo o/r"])
+    Session["<b>Resolve Session</b><br/>flag → env → browser<br/><i>(kooky for browser)</i>"]
+
+    Start --> Session
+
+    subgraph PerImage ["For each image"]
+        direction TB
+        Token["<b>Fetch uploadToken</b><br/>GET /:owner/:repo"]
+        Policy["<b>Request Policy</b><br/>POST /upload/policies/assets"]
+        S3["<b>Upload to S3</b><br/>POST policy.upload_url<br/><i>(no GitHub auth)</i>"]
+        Finalize["<b>Finalize</b><br/>PUT /upload/assets/:id"]
+        Print["<b>Print markdown</b><br/>to stdout"]
+
+        Token -- "uploadToken" --> Policy
+        Policy -- "S3 presigned form +<br/>asset_upload_authenticity_token" --> S3
+        S3 -- "200 / 201 / 204" --> Finalize
+        Finalize -- "asset href URL" --> Print
+    end
+
+    Session -- "user_session" --> Token
+
+    classDef ghAuth fill:#e8f0ff,stroke:#4a6fa5,color:#000
+    classDef s3 fill:#fff4e0,stroke:#c08a2e,color:#000
+    classDef terminal fill:#e8f5e8,stroke:#5a8a5a,color:#000
+    class Session,Token,Policy,Finalize ghAuth
+    class S3 s3
+    class Start,Print terminal
 ```
 
 ## Authentication Model

--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -2,20 +2,28 @@
 
 ## Overview
 
-`gh-image` is a Go CLI tool distributed as a `gh` extension. It uploads images to GitHub using the same internal API that the web UI uses when you drag-and-drop or paste an image. The tool handles browser cookie extraction, CSRF token negotiation, and S3 presigned uploads, then prints the resulting markdown image reference to stdout.
+`gh-image` is a Go CLI tool distributed as a `gh` extension. It uploads images to GitHub using the same internal API that the web UI uses when you drag-and-drop or paste an image. The tool resolves a GitHub session (from a flag, env var, or browser cookie store), negotiates upload tokens, performs an S3 presigned upload, then prints the resulting markdown image reference to stdout.
 
 ## Project Structure
 
 ```
 gh-image/
-├── main.go                          # CLI entrypoint, argument parsing
+├── main.go                          # CLI entrypoint, arg parsing, subcommand dispatch
+├── main_test.go
 ├── go.mod
 ├── go.sum
 ├── internal/
 │   ├── cookies/
-│   │   └── cookies.go               # Chrome cookie extraction via kooky
+│   │   ├── cookies.go               # Browser session cookie extraction via kooky
+│   │   ├── jar.go                   # GitHub cookie jar + same-site pair construction
+│   │   └── jar_test.go
+│   ├── session/
+│   │   ├── session.go               # Session token validation (check-token)
+│   │   └── session_test.go
+│   ├── httputil/
+│   │   └── httputil.go              # Shared User-Agent constant
 │   ├── upload/
-│   │   ├── upload.go                # Orchestrates the 3-step upload flow
+│   │   ├── upload.go                # Orchestrates the 3-step upload flow + HTTP client
 │   │   ├── token.go                 # Fetches uploadToken from repo page
 │   │   └── s3.go                    # S3 presigned multipart upload
 │   └── repo/
@@ -28,30 +36,82 @@ gh-image/
         └── release.yml              # GoReleaser cross-compilation + release
 ```
 
+## CLI Surface
+
+```
+gh image [--repo owner/repo] [--token <value>] <image-path>...
+gh image extract-token
+gh image check-token [--token <value>]
+```
+
+- **Default mode** uploads one or more image files and prints markdown references to stdout. Flags may appear before or after positional args; use `--` to pass filenames that begin with `-`.
+- **`extract-token`** reads the session cookie from the browser and prints the raw token value to stdout (status info to stderr). Useful for piping into CI secrets.
+- **`check-token`** resolves a token using the standard precedence (flag → env → browser) and verifies it against GitHub, printing the authenticated username on success.
+
+### Session Token Sources
+
+The session token is resolved with the following precedence (first match wins):
+
+1. `--token <value>` flag
+2. `GH_SESSION_TOKEN` environment variable
+3. Browser cookie store (via `kooky`)
+
+The flag is convenient for one-off use; the env var is the recommended path for CI/CD and shared machines, since `--token` values are visible in process listings. Browser extraction is the zero-config path for local interactive use.
+
 ## Component Design
 
-### 1. Cookie Extraction (`internal/cookies/`)
+### 1. Cookie Extraction (`internal/cookies/cookies.go`)
 
-Reads the GitHub `user_session` cookie from the local Chrome cookie database.
+Reads the GitHub `user_session` cookie from local browser cookie stores.
 
 **Dependency:** [`browserutils/kooky`](https://github.com/browserutils/kooky) — a pure Go library that handles:
-- Locating Chrome's SQLite cookie database on disk
-- Retrieving the encryption key from macOS Keychain
-- AES-128-CBC decryption (PBKDF2-derived key, `saltysalt`, 1003 iterations)
-- Cookie DB schema differences across Chromium versions
+- Locating each browser's cookie store on disk
+- Retrieving encryption keys (macOS Keychain, Windows DPAPI, Linux GNOME Keyring / kwallet)
+- AES decryption and cookie DB schema differences across versions
+- Per-browser quirks for Chromium-family browsers, Firefox, Safari, and Opera
 
-**Interface:**
+**Supported browsers** (registered via blank-imported kooky finders): Chrome, Brave, Edge, Chromium, Firefox, Opera, Safari. `GetGitHubSession` queries all of them in one pass and returns the first valid `user_session` cookie found.
 
 ```go
 // GetGitHubSession returns the user_session cookie for github.com.
-// It searches Chrome, Brave, Edge, and Chromium in order, returning
-// the cookie from the first browser with a valid GitHub session.
+// It searches all registered browsers in one pass and returns the cookie
+// from the first browser that has one.
 func GetGitHubSession() (*http.Cookie, error)
 ```
 
-The only cookie needed from the browser is `user_session`. The `__Host-user_session_same_site` cookie is a duplicate of `user_session` with a stricter SameSite policy — it has the same value, so the client synthesizes it from `user_session` rather than reading it separately. The `_gh_sess` cookie rotates with each GitHub response and is managed automatically by the HTTP client's cookie jar — it does not need to be read from the browser's cookie store. Using `kooky` means we don't maintain any crypto or Keychain code ourselves.
+The only cookie that needs to be read from the browser is `user_session`. The `__Host-user_session_same_site` cookie is a strict-SameSite duplicate with the same value, so it is synthesized rather than read separately (see Cookie Jar below). The `_gh_sess` cookie rotates with each GitHub response and is managed automatically by the HTTP client's cookie jar.
 
-### 2. Repository Resolution (`internal/repo/`)
+### 2. Cookie Jar (`internal/cookies/jar.go`)
+
+Constructs an `http.CookieJar` pre-loaded with the `user_session` cookie and its synthesized `__Host-user_session_same_site` counterpart, both scoped to `https://github.com`. GitHub's CSRF validation requires both cookies on the upload endpoints.
+
+```go
+// SessionCookiePair returns the user_session cookie and its
+// __Host-user_session_same_site counterpart synthesized from it.
+func SessionCookiePair(sessionCookie *http.Cookie) [2]*http.Cookie
+
+// NewGitHubCookieJar creates a cookie jar pre-loaded with the session pair
+// for https://github.com.
+func NewGitHubCookieJar(sessionCookie *http.Cookie) http.CookieJar
+```
+
+### 3. Session Validation (`internal/session/`)
+
+Verifies a session cookie is valid by fetching `https://github.com/settings/profile` and inspecting the response. A 200 confirms validity; a redirect to login means the token is expired or invalid. When the response body contains a `<meta name="user-login" ...>` tag, the username is extracted and returned.
+
+```go
+// CheckValidity verifies a GitHub session cookie is valid and returns
+// the authenticated username on success.
+func CheckValidity(sessionCookie *http.Cookie) (string, error)
+```
+
+This package is what powers the `check-token` subcommand. It uses `cookies.SessionCookiePair` and `httputil.UserAgent` so its requests look identical to the upload flow's.
+
+### 4. HTTP Utilities (`internal/httputil/`)
+
+Holds shared HTTP plumbing that needs to be consistent across packages. Currently a single `UserAgent` constant — a recent Chrome desktop UA string — used by both the upload flow and the session validator so all GitHub requests present a uniform identity.
+
+### 5. Repository Resolution (`internal/repo/`)
 
 Resolves the target GitHub repository's owner, name, and numeric ID.
 
@@ -70,9 +130,18 @@ func LookupID(owner, name string) (int, error)
 func Resolve(owner, name string) (*Info, error)
 ```
 
-### 3. Upload Flow (`internal/upload/`)
+### 6. Upload Flow (`internal/upload/`)
 
-Implements the 3-step upload protocol documented in [github-image-upload-flow.md](github-image-upload-flow.md). All HTTP requests use a shared `http.Client` with a cookie jar so that `_gh_sess` rotation is handled automatically.
+Implements the 3-step upload protocol documented in [github-image-upload-flow.md](github-image-upload-flow.md). All GitHub-bound requests use a shared `http.Client` whose cookie jar is built by `cookies.NewGitHubCookieJar`, so `_gh_sess` rotation is handled automatically.
+
+```go
+// NewClient creates an http.Client with the GitHub session cookies set.
+func NewClient(sessionCookie *http.Cookie) *http.Client
+
+// Upload uploads an image file to GitHub and returns the asset URL,
+// sanitized filename, and a ready-to-paste markdown reference.
+func Upload(client *http.Client, owner, repo string, repoID int, imagePath string) (*Result, error)
+```
 
 #### Token Retrieval (`token.go`)
 
@@ -108,6 +177,7 @@ finalizeUpload()       ──→  PUT /upload/assets/{asset_id}
 
 **Key implementation details:**
 - The `form` fields from the policy response must be sent to S3 exactly as-is. Adding extra fields (e.g., duplicate `Content-Type`) causes S3 to reject the upload with a 403 policy violation.
+- Fields are written in a deterministic order (see `s3FieldOrder` in `s3.go`). Go map iteration is nondeterministic, and we observed empirically that S3 presigned POSTs can be sensitive to field order; the known keys are emitted first, then any unrecognized keys, so future additions still flow through.
 - The `file` field must be the **last** field in the multipart form.
 - The finalize step uses `asset_upload_authenticity_token` from the policy response, **not** the `uploadToken` from step 0. Each step produces the token needed for the next step (see [Token Relationships](github-image-upload-flow.md#token-relationships)).
 - The finalize step is mandatory — without it, the asset URL returns 404.
@@ -116,21 +186,33 @@ finalizeUpload()       ──→  PUT /upload/assets/{asset_id}
 
 Handles the multipart form construction for the S3 presigned upload. Separated from the main orchestration because the S3 request has different requirements (no cookies, no GitHub headers, just the presigned form fields and file data).
 
+### 7. CLI Entrypoint (`main.go`)
+
+Responsibilities:
+
+- **Manual arg parsing** so that flags can appear before or after positional args, with `--` as an explicit terminator for filenames starting with a dash.
+- **Subcommand dispatch** for `extract-token` and `check-token`, with validation that disallowed flag combinations are rejected before any work is done.
+- **Session resolution** via `resolveSessionCookie`, which applies the flag → env → browser precedence and wraps raw token values into a properly scoped `*http.Cookie`.
+- **Multi-image upload loop**: each positional path is uploaded independently. A failure on one image is reported to stderr and the loop continues; the process exits non-zero if any upload failed.
+
 ## Data Flow
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│  User: gh image screenshot.png --repo o/r                    │
+│  User: gh image screenshot.png another.png --repo o/r       │
 └──────────────────────────┬──────────────────────────────────┘
                            │
                            ▼
                 ┌──────────────────────┐
-                │   Cookie Extraction  │
-                │   (kooky + Keychain) │
+                │  Resolve Session     │
+                │  flag > env > browser│
+                │  (kooky for browser) │
                 └──────────┬───────────┘
                            │ user_session
                            ▼
                 ┌──────────────────────┐
+                │  For each image:     │
+                │                      │
                 │  Fetch uploadToken   │
                 │  GET /repo page      │
                 └──────────┬───────────┘
@@ -146,10 +228,10 @@ Handles the multipart form construction for the S3 presigned upload. Separated f
                            ▼
                 ┌──────────────────────┐
                 │  Upload to S3        │
-                │  POST s3.aws.com     │
-                │  (no GitHub auth)    │
+                │  POST policy.upload_ │
+                │  url (no GitHub auth)│
                 └──────────┬───────────┘
-                           │ 204 OK
+                           │ 200 / 201 / 204
                            ▼
                 ┌──────────────────────┐
                 │  Finalize            │
@@ -166,15 +248,14 @@ Handles the multipart form construction for the S3 presigned upload. Separated f
 
 ## Authentication Model
 
-The tool uses browser cookies for all GitHub requests:
-
 | Action | Auth Method | Source |
 |---|---|---|
-| Steps 0, 1, 3 (GitHub requests) | `user_session` + `__Host-user_session_same_site` cookies | Browser cookie DB (via kooky) |
+| Steps 0, 1, 3 (GitHub requests) | `user_session` + `__Host-user_session_same_site` cookies | `--token` flag, `GH_SESSION_TOKEN`, or browser cookie DB (via kooky) |
 | Step 2 (S3 upload) | None | Presigned policy from step 1 |
 | Repo ID lookup | OAuth token | `gh` CLI (via `gh auth`) |
+| `check-token` validation | Same `user_session` pair | Same precedence as upload |
 
-The cookie and `gh` CLI auth paths are independent — the cookie provides a browser-equivalent session for the undocumented upload API, while `gh` handles the standard REST API for looking up the numeric repository ID.
+The session-cookie path and the `gh` CLI auth path are independent. The cookie provides a browser-equivalent session for the undocumented upload API, while `gh` handles the standard REST API used only for looking up the numeric repository ID.
 
 ## Distribution
 
@@ -183,12 +264,12 @@ Built as a [`gh` CLI extension](https://cli.github.com/manual/gh_extension):
 - Repository is named `gh-image` so it installs as `gh image`
 - GoReleaser builds binaries for macOS (arm64, amd64), Linux (amd64, arm64), and Windows (amd64) on tagged releases
 - `gh extension install` auto-detects the user's platform and downloads the correct binary from the GitHub Release
-- Single static binary, no runtime dependencies
+- Single static binary, no runtime dependencies (beyond the `gh` CLI and `git`)
 
 ### Release Flow
 
 ```
-git tag v0.1.0
+git tag vX.Y.Z
 git push --tags
 → GitHub Actions triggers
   → GoReleaser cross-compiles
@@ -200,20 +281,20 @@ git push --tags
 
 | Dependency | Purpose |
 |---|---|
-| [`browserutils/kooky`](https://github.com/browserutils/kooky) | Chrome cookie extraction (Keychain + AES + SQLite) |
-| Go standard library `net/http` | HTTP client for upload flow |
+| [`browserutils/kooky`](https://github.com/browserutils/kooky) | Cross-browser cookie extraction (Keychain / DPAPI / Keyring + AES + SQLite/ESE) |
+| Go standard library `net/http` | HTTP client + cookie jar for the upload flow |
 | Go standard library `mime/multipart` | Multipart form construction |
 | Go standard library `encoding/json` | JSON parsing |
-| Go standard library `regexp` | uploadToken extraction |
+| Go standard library `regexp` | uploadToken and `user-login` extraction |
 
 ## Platform Notes
 
-- **macOS:** Fully supported. A Keychain prompt may appear on first use to authorize access to the browser's cookie encryption key. Click "Always Allow" to avoid repeated prompts.
-- **Linux:** kooky supports Linux (GNOME Keyring / kwallet for Chrome key storage). The upload flow is platform-agnostic. Main gap is testing.
-- **Windows:** kooky supports Windows (DPAPI for Chrome cookie decryption). Binaries are built for Windows amd64. Main gap is testing.
+- **macOS:** Fully supported. On first browser-cookie use, a Keychain prompt may appear to authorize access to the browser's cookie encryption key. Click "Always Allow" to avoid repeated prompts. Safari is supported in addition to Chromium-family browsers.
+- **Linux:** Supported via kooky (GNOME Keyring / kwallet for Chromium-family key storage; Firefox profile DBs read directly). The upload flow is platform-agnostic.
+- **Windows:** Supported via kooky (DPAPI for Chromium-family cookie decryption). Binaries are built for Windows amd64.
+- **CI / headless environments:** Use `GH_SESSION_TOKEN` (preferred) or `--token` to skip browser extraction entirely.
 
 ## Future Considerations
 
-- **Firefox support:** kooky supports Firefox cookies. Would need to detect which browser has a GitHub session.
 - **Clipboard image support:** Accept image data from clipboard (`gh image paste --repo o/r`) instead of requiring a file path.
-- **Token caching:** The `uploadToken` could be cached briefly to avoid fetching the repo page on every upload. The presigned S3 policy expires in ~30 minutes, so caching is safe within that window.
+- **Token caching:** The `uploadToken` could be cached briefly to avoid fetching the repo page on every upload within a multi-image batch. The presigned S3 policy expires in ~30 minutes, so reuse is safe within that window.

--- a/main.go
+++ b/main.go
@@ -16,7 +16,11 @@ import (
 const usage = `Usage:
   gh image [--repo owner/repo] [--token <value>] <image-path>...
   gh image extract-token
-  gh image check-token [--token <value>]`
+  gh image check-token [--token <value>]
+  gh image --version`
+
+// version is set via -ldflags "-X main.version=..." at release build time.
+var version = "dev"
 
 func main() {
 	var repoFlag string
@@ -90,6 +94,9 @@ func main() {
 				os.Exit(1)
 			}
 			tokenSet = true
+		case arg == "--version":
+			fmt.Printf("gh-image %s\n", version)
+			os.Exit(0)
 		case arg == "--help" || arg == "-h":
 			fmt.Printf("%s\n\n", usage)
 			fmt.Println("Upload images to GitHub and print markdown references.")
@@ -103,6 +110,7 @@ func main() {
 			fmt.Println("                      Can also be set via GH_SESSION_TOKEN environment variable")
 			fmt.Println("                      WARNING: --token values are visible in process listings.")
 			fmt.Println("                      Prefer GH_SESSION_TOKEN on shared machines.")
+			fmt.Println("  --version           Print version and exit")
 			fmt.Println()
 			fmt.Println("Subcommands:")
 			fmt.Println("  extract-token       Extract session token from browser and print to stdout")


### PR DESCRIPTION
## Summary

Two commits' worth of prep work to get the repo ready for a v1.0.0 cut.

**Docs polish** (`9d1d1fc`)
- README rewrite to production-grade layout: hero block with banner; badges for release / stars / downloads / license / Go Report Card; instant demo; restructured Installation, Usage, Authentication, and CI/CD sections.
- CI/CD now leads with the bot-account caution, then setup steps that recommend an **environment secret** with branch restrictions instead of a plain repo secret.
- `documentation/architecture.md` refreshed for current packages (`session`, `httputil`, `cookies/jar`), multi-browser support (Chrome, Brave, Edge, Chromium, Firefox, Opera, Safari), S3 status-code corrections, and the deterministic field-ordering note.
- `LICENSE`: extend copyright to `2025-2026`.

**Release readiness items** (`46e33c1`)
- `.github/workflows/test.yml` — PR-time CI (`go vet`, `go test -race -cover`, `go build`). README told contributors to run these; nothing enforced it.
- `.github/dependabot.yml` — weekly `gomod` + `github-actions` updates. Particularly relevant for `kooky`, which gates the Windows Chrome 127+ ABE fix (#4).
- `main.go` + `.goreleaser.yml` — `--version` flag, with the version constant injected at release-build time via `-X main.version={{.Version}}` ldflags. Local builds report `dev`.
- `SECURITY.md` — disclosure policy via GitHub private vulnerability reporting, supported-versions table, pointer to the README's leak-remediation flow.
- README: NOTE callout under Authentication documenting that Chrome 127+ on Windows is not yet supported by `kooky`'s ABE handling (tracking #4) — previously the README claimed unconditional Windows support.

## Items intentionally deferred

The pre-release audit ([REVIEW.md](https://github.com/drogers0/gh-image/blob/docs/v1-release-prep/) — not committed) flagged a few more items. Skipped for this PR:

- **Tests for `internal/upload/`** — core protocol code is at 0% unit coverage. Real risk, but bounded (1,500+ downloads across 3 releases have functionally exercised the path). Better as a focused follow-up than a rushed addition here.
- **CHANGELOG.md, CONTRIBUTING.md, CODE_OF_CONDUCT.md, FUNDING.yml, issue templates** — judged as cargo-culted for a solo-maintainer project of this scope. GitHub Releases serve the CHANGELOG role; the README has a Contributing section.

## Test plan

- [x] `go vet ./...` passes locally
- [x] `go test -race ./...` passes locally
- [x] `go build -ldflags "-X main.version=1.0.0-test" .` and `./gh-image --version` prints `gh-image 1.0.0-test`
- [x] New `test.yml` workflow runs green on this PR
- [x] README renders correctly on github.com (badges show, callouts render as alerts, banner displays)
- [x] `SECURITY.md` surfaces as a "Security Policy" tab on the repo page after merge
- [x] Confirm `dependabot.yml` is picked up (Settings → Code security → Dependabot version updates shows it active)