### PR TITLE
Pin GoReleaser CLI to ~> v2 instead of 'latest'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The v1.0.0 release run surfaced:

> *You are using 'latest' as default version. Will lock to '~> v2'.*

Making the lock explicit avoids silent breakage if GoReleaser ships a v3 with behavior changes. \`~> v2\` accepts any v2.x release (minor+patch updates flow in automatically) but blocks a major bump.

This pairs with #13 (which bumped \`goreleaser/goreleaser-action@v6\` → \`@v7\`) to clear both warnings raised on the v1.0.0 release workflow run.

## Test plan

- [ ] CI passes on this PR
- [ ] Next tag-triggered release run no longer emits the "Will lock to" warning