### PR TITLE
Detect SAML SSO interstitial and give an actionable error

### DIFF
--- a/internal/upload/token.go
+++ b/internal/upload/token.go
@@ -26,8 +26,13 @@ var uploadTokenRe = regexp.MustCompile(`"uploadToken":"([^"]+)"`)
 // page: those appear in GitHub's site chrome/help links on virtually every page
 // (and in any repo that is simply about SAML), which would be a false positive.
 func isSAMLProtected(body []byte, owner string) bool {
+	if owner == "" {
+		return false
+	}
+	// Owners are case-insensitive on GitHub, and the page may render a different
+	// case than the user typed, so both checks are case-insensitive.
 	o := regexp.QuoteMeta(owner)
-	orgSSOLink := regexp.MustCompile(`/orgs/` + o + `/sso`).Match(body)
+	orgSSOLink := regexp.MustCompile(`(?i)/orgs/` + o + `/sso`).Match(body)
 	ssoTitle := regexp.MustCompile(`(?i)<title>\s*Sign in to ` + o + `\b`).Match(body)
 	return orgSSOLink || ssoTitle
 }

--- a/internal/upload/token.go
+++ b/internal/upload/token.go
@@ -65,11 +65,10 @@ func GetUploadToken(client *http.Client, owner, repo string) (string, error) {
 		if isSAMLProtected(body, owner) {
 			return "", fmt.Errorf("%s enforces SAML SSO and your session is not authorized for it — "+
 				"authorize in a browser at https://github.com/orgs/%s/sso (lasts ~24h), then retry. "+
-				"This is NOT a write-access problem, and copying additional cookies cannot fix it "+
-				"(the SSO grant is server-side)", owner, owner)
+				"Write access alone is not enough", owner, owner)
 		}
 		return "", fmt.Errorf("uploadToken not found on repo page — do you have write access to %s/%s? "+
-			"(if %s enforces SAML SSO, authorize your session at https://github.com/orgs/%s/sso and retry)",
+			"(or, if %s enforces SAML SSO, authorize at https://github.com/orgs/%s/sso)",
 			owner, repo, owner, owner)
 	}
 

--- a/internal/upload/token.go
+++ b/internal/upload/token.go
@@ -11,6 +11,27 @@ import (
 
 var uploadTokenRe = regexp.MustCompile(`"uploadToken":"([^"]+)"`)
 
+// isSAMLProtected reports whether the repo page is a SAML SSO "Sign in to
+// <owner>" interstitial rather than the real repo page. When an organization
+// enforces SAML SSO and the browser session is authenticated but not
+// SSO-authorized for that org, GitHub serves this interstitial with HTTP 200 —
+// so the uploadToken is absent even though the user has write access.
+//
+// The SSO authorization is server-side state (it lasts ~24h and is granted only
+// by completing the identity-provider handshake in a browser), so it is NOT a
+// cookie that can be copied; the fix is to re-authorize at /orgs/<owner>/sso.
+//
+// We require signals SPECIFIC to the interstitial and scoped to THIS owner. We
+// deliberately do NOT match the words "SAML"/"single sign-on" anywhere on the
+// page: those appear in GitHub's site chrome/help links on virtually every page
+// (and in any repo that is simply about SAML), which would be a false positive.
+func isSAMLProtected(body []byte, owner string) bool {
+	o := regexp.QuoteMeta(owner)
+	orgSSOLink := regexp.MustCompile(`/orgs/` + o + `/sso`).Match(body)
+	ssoTitle := regexp.MustCompile(`(?i)<title>\s*Sign in to ` + o + `\b`).Match(body)
+	return orgSSOLink || ssoTitle
+}
+
 // GetUploadToken fetches the repo page and extracts the uploadToken
 // from the JS payload. Requires authenticated cookies in the client.
 func GetUploadToken(client *http.Client, owner, repo string) (string, error) {
@@ -39,7 +60,17 @@ func GetUploadToken(client *http.Client, owner, repo string) (string, error) {
 
 	match := uploadTokenRe.FindSubmatch(body)
 	if match == nil {
-		return "", fmt.Errorf("uploadToken not found on repo page — do you have write access to %s/%s?", owner, repo)
+		// Distinguish the common SAML-SSO case from a genuine lack of access, so
+		// the user isn't wrongly told to check their permissions.
+		if isSAMLProtected(body, owner) {
+			return "", fmt.Errorf("%s enforces SAML SSO and your session is not authorized for it — "+
+				"authorize in a browser at https://github.com/orgs/%s/sso (lasts ~24h), then retry. "+
+				"This is NOT a write-access problem, and copying additional cookies cannot fix it "+
+				"(the SSO grant is server-side)", owner, owner)
+		}
+		return "", fmt.Errorf("uploadToken not found on repo page — do you have write access to %s/%s? "+
+			"(if %s enforces SAML SSO, authorize your session at https://github.com/orgs/%s/sso and retry)",
+			owner, repo, owner, owner)
 	}
 
 	return string(match[1]), nil

--- a/internal/upload/token_test.go
+++ b/internal/upload/token_test.go
@@ -52,6 +52,28 @@ func TestIsSAMLProtected(t *testing.T) {
 			body:  `<title>Sign in to axb</title>`, // '.' must NOT act as a wildcard
 			want:  false,
 		},
+		{
+			// GitHub owners are case-insensitive and the page may render a
+			// different case than the user typed; the link must still match.
+			name:  "lowercase owner matches a canonical-case sso link",
+			owner: "gympod",
+			body:  `<a href="/orgs/GymPod/sso">Single sign-on</a>`,
+			want:  true,
+		},
+		{
+			// Substring of another org's name must not match.
+			name:  "owner that is a substring of another org must NOT match",
+			owner: "pod",
+			body:  `<a href="/orgs/GymPod/sso">x</a>`,
+			want:  false,
+		},
+		{
+			// Defensive: an empty owner must never match (and must not panic).
+			name:  "empty owner never matches",
+			owner: "",
+			body:  `<a href="/orgs/Anything/sso"><title>Sign in to </title>`,
+			want:  false,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/upload/token_test.go
+++ b/internal/upload/token_test.go
@@ -81,7 +81,7 @@ func TestGetUploadToken(t *testing.T) {
 			name:        "SAML interstitial gives an actionable SSO error, not write-access",
 			owner:       "GymPod",
 			body:        `<title>Sign in to GymPod</title><a href="/orgs/GymPod/sso">Single sign-on</a>`,
-			errContains: []string{"SAML SSO", "/orgs/GymPod/sso", "NOT a write-access problem"},
+			errContains: []string{"SAML SSO", "/orgs/GymPod/sso", "Write access alone is not enough"},
 			errExcludes: []string{"do you have write access to GymPod"},
 		},
 		{

--- a/internal/upload/token_test.go
+++ b/internal/upload/token_test.go
@@ -1,0 +1,142 @@
+package upload
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// serve returns an httptest server that responds with status/body, and a client
+// pointed at it. GetUploadToken builds a github.com URL internally, so these
+// tests exercise isSAMLProtected / the error wording directly where the URL is
+// fixed, and use the server only for the HTTP-shape tests below.
+func serve(status int, body string) (*httptest.Server, *http.Client) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	return srv, srv.Client()
+}
+
+func TestIsSAMLProtected(t *testing.T) {
+	cases := []struct {
+		name  string
+		owner string
+		body  string
+		want  bool
+	}{
+		{
+			name:  "SSO interstitial title",
+			owner: "GymPod",
+			body:  `<title>Sign in to GymPod</title>`,
+			want:  true,
+		},
+		{
+			name:  "owner-scoped /orgs/<owner>/sso link",
+			owner: "GymPod",
+			body:  `<a href="/orgs/GymPod/sso?return_to=%2FGymPod%2Frepo">Single sign-on</a>`,
+			want:  true,
+		},
+		{
+			// The key false positive the naive "contains SAML" check would hit:
+			// site chrome / help links mention SSO on essentially every page.
+			name:  "normal repo page with SSO words in chrome must NOT match",
+			owner: "GymPod",
+			body:  `<title>GymPod/realtime-core</title><footer><a href="/help/saml">single sign-on docs</a></footer>`,
+			want:  false,
+		},
+		{
+			name:  "a repo that is ABOUT saml must NOT match",
+			owner: "crewjam",
+			body:  `<title>GitHub - crewjam/saml: SAML library for go</title> ... single sign-on ...`,
+			want:  false,
+		},
+		{
+			name:  "another org's sso link must NOT match this owner",
+			owner: "GymPod",
+			body:  `<a href="/orgs/SomeOtherOrg/sso">x</a>`,
+			want:  false,
+		},
+		{
+			name:  "owner with regex metacharacters is matched literally",
+			owner: "a.b",
+			body:  `<title>Sign in to axb</title>`, // '.' must NOT act as a wildcard
+			want:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSAMLProtected([]byte(tc.body), tc.owner); got != tc.want {
+				t.Errorf("isSAMLProtected(%q owner=%q) = %v, want %v", tc.body, tc.owner, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetUploadToken_Success(t *testing.T) {
+	srv, client := serve(http.StatusOK, `window.foo={"uploadToken":"TKN123"};`)
+	defer srv.Close()
+
+	// GetUploadToken hardcodes the github.com URL, so we can't redirect it at the
+	// server here; instead verify extraction via the regex contract the function
+	// relies on. (The SSO/error wording is covered by the table tests above.)
+	match := uploadTokenRe.FindSubmatch([]byte(`{"uploadToken":"TKN123"}`))
+	if match == nil || string(match[1]) != "TKN123" {
+		t.Fatalf("uploadTokenRe failed to extract token")
+	}
+	_ = client
+}
+
+func TestGetUploadToken_SAMLErrorWording(t *testing.T) {
+	// Drive GetUploadToken through a stubbed transport so we control the body it
+	// reads from "github.com" without a real network call.
+	client := &http.Client{Transport: stubTransport(http.StatusOK,
+		`<title>Sign in to GymPod</title><a href="/orgs/GymPod/sso">Single sign-on</a>`)}
+
+	_, err := GetUploadToken(client, "GymPod", "realtime-core")
+	if err == nil {
+		t.Fatal("expected an error for the SSO interstitial")
+	}
+	msg := err.Error()
+	for _, want := range []string{"SAML SSO", "/orgs/GymPod/sso", "NOT a write-access problem"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message missing %q; got: %s", want, msg)
+		}
+	}
+	if strings.Contains(msg, "do you have write access") {
+		t.Errorf("SSO error should not use the misleading write-access wording; got: %s", msg)
+	}
+}
+
+func TestGetUploadToken_GenericErrorWording(t *testing.T) {
+	// No token and no SSO markers → the generic message (with an SSO hint).
+	client := &http.Client{Transport: stubTransport(http.StatusOK, `<html>just a page, no token</html>`)}
+
+	_, err := GetUploadToken(client, "octocat", "hello")
+	if err == nil {
+		t.Fatal("expected an error when uploadToken is absent")
+	}
+	if !strings.Contains(err.Error(), "do you have write access to octocat/hello") {
+		t.Errorf("expected the generic write-access message; got: %s", err.Error())
+	}
+}
+
+// stubTransport returns an http.RoundTripper that answers every request with the
+// given status and body, so GetUploadToken's hardcoded github.com URL is served
+// locally.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func stubTransport(status int, body string) http.RoundTripper {
+	return roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: status,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+			Request:    r,
+		}, nil
+	})
+}

--- a/internal/upload/token_test.go
+++ b/internal/upload/token_test.go
@@ -3,22 +3,9 @@ package upload
 import (
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 )
-
-// serve returns an httptest server that responds with status/body, and a client
-// pointed at it. GetUploadToken builds a github.com URL internally, so these
-// tests exercise isSAMLProtected / the error wording directly where the URL is
-// fixed, and use the server only for the HTTP-shape tests below.
-func serve(status int, body string) (*httptest.Server, *http.Client) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(status)
-		_, _ = w.Write([]byte(body))
-	}))
-	return srv, srv.Client()
-}
 
 func TestIsSAMLProtected(t *testing.T) {
 	cases := []struct {
@@ -40,7 +27,7 @@ func TestIsSAMLProtected(t *testing.T) {
 			want:  true,
 		},
 		{
-			// The key false positive the naive "contains SAML" check would hit:
+			// The key false positive a naive "contains SAML" check would hit:
 			// site chrome / help links mention SSO on essentially every page.
 			name:  "normal repo page with SSO words in chrome must NOT match",
 			owner: "GymPod",
@@ -75,57 +62,70 @@ func TestIsSAMLProtected(t *testing.T) {
 	}
 }
 
-func TestGetUploadToken_Success(t *testing.T) {
-	srv, client := serve(http.StatusOK, `window.foo={"uploadToken":"TKN123"};`)
-	defer srv.Close()
-
-	// GetUploadToken hardcodes the github.com URL, so we can't redirect it at the
-	// server here; instead verify extraction via the regex contract the function
-	// relies on. (The SSO/error wording is covered by the table tests above.)
-	match := uploadTokenRe.FindSubmatch([]byte(`{"uploadToken":"TKN123"}`))
-	if match == nil || string(match[1]) != "TKN123" {
-		t.Fatalf("uploadTokenRe failed to extract token")
+func TestGetUploadToken(t *testing.T) {
+	cases := []struct {
+		name        string
+		owner       string
+		body        string
+		wantToken   string   // non-empty => expect success
+		errContains []string // substrings the error must include
+		errExcludes []string // substrings the error must NOT include
+	}{
+		{
+			name:      "success extracts the token",
+			owner:     "octocat",
+			body:      `window.x={"uploadToken":"TKN123"};`,
+			wantToken: "TKN123",
+		},
+		{
+			name:        "SAML interstitial gives an actionable SSO error, not write-access",
+			owner:       "GymPod",
+			body:        `<title>Sign in to GymPod</title><a href="/orgs/GymPod/sso">Single sign-on</a>`,
+			errContains: []string{"SAML SSO", "/orgs/GymPod/sso", "NOT a write-access problem"},
+			errExcludes: []string{"do you have write access to GymPod"},
+		},
+		{
+			name:        "no token and no SSO markers gives the generic message",
+			owner:       "octocat",
+			body:        `<html>just a page, no token</html>`,
+			errContains: []string{"do you have write access to octocat/hello"},
+		},
 	}
-	_ = client
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &http.Client{Transport: stubTransport(http.StatusOK, tc.body)}
+			tok, err := GetUploadToken(client, tc.owner, "hello")
+
+			if tc.wantToken != "" {
+				if err != nil {
+					t.Fatalf("expected success, got error: %v", err)
+				}
+				if tok != tc.wantToken {
+					t.Errorf("token = %q, want %q", tok, tc.wantToken)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			for _, s := range tc.errContains {
+				if !strings.Contains(err.Error(), s) {
+					t.Errorf("error missing %q; got: %s", s, err.Error())
+				}
+			}
+			for _, s := range tc.errExcludes {
+				if strings.Contains(err.Error(), s) {
+					t.Errorf("error should not contain %q; got: %s", s, err.Error())
+				}
+			}
+		})
+	}
 }
 
-func TestGetUploadToken_SAMLErrorWording(t *testing.T) {
-	// Drive GetUploadToken through a stubbed transport so we control the body it
-	// reads from "github.com" without a real network call.
-	client := &http.Client{Transport: stubTransport(http.StatusOK,
-		`<title>Sign in to GymPod</title><a href="/orgs/GymPod/sso">Single sign-on</a>`)}
-
-	_, err := GetUploadToken(client, "GymPod", "realtime-core")
-	if err == nil {
-		t.Fatal("expected an error for the SSO interstitial")
-	}
-	msg := err.Error()
-	for _, want := range []string{"SAML SSO", "/orgs/GymPod/sso", "NOT a write-access problem"} {
-		if !strings.Contains(msg, want) {
-			t.Errorf("error message missing %q; got: %s", want, msg)
-		}
-	}
-	if strings.Contains(msg, "do you have write access") {
-		t.Errorf("SSO error should not use the misleading write-access wording; got: %s", msg)
-	}
-}
-
-func TestGetUploadToken_GenericErrorWording(t *testing.T) {
-	// No token and no SSO markers → the generic message (with an SSO hint).
-	client := &http.Client{Transport: stubTransport(http.StatusOK, `<html>just a page, no token</html>`)}
-
-	_, err := GetUploadToken(client, "octocat", "hello")
-	if err == nil {
-		t.Fatal("expected an error when uploadToken is absent")
-	}
-	if !strings.Contains(err.Error(), "do you have write access to octocat/hello") {
-		t.Errorf("expected the generic write-access message; got: %s", err.Error())
-	}
-}
-
-// stubTransport returns an http.RoundTripper that answers every request with the
-// given status and body, so GetUploadToken's hardcoded github.com URL is served
-// locally.
+// stubTransport answers every request with the given status and body, so
+// GetUploadToken's hardcoded github.com URL is served locally without a network
+// call.
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }


### PR DESCRIPTION
## Problem

When a repo belongs to an org that enforces **SAML SSO** and your browser session is authenticated but **not SSO-authorized for that org**, GitHub serves a "Sign in to *org*" interstitial page with **HTTP 200** — so `uploadToken` is absent even though you have full write access.

Today that surfaces as:

```
uploadToken not found on repo page — do you have write access to <owner>/<repo>?
```

…which sends the user down the wrong path: they *do* have write access (often admin), and the real fix is a 10-second SSO re-authorization. An SSO session is **server-side state** (~24h, granted only by completing the IdP handshake in a browser), so it is not something more cookies can supply.

## Change

`GetUploadToken` now detects the SSO interstitial and points the user at `/orgs/<owner>/sso`:

**Before**
```
Error uploading shot.png: step 0 (get upload token): uploadToken not found on repo page — do you have write access to GymPod/realtime-core?
```
**After**
```
Error uploading shot.png: step 0 (get upload token): GymPod enforces SAML SSO and your session is not authorized for it — authorize in a browser at https://github.com/orgs/GymPod/sso (lasts ~24h), then retry. Write access alone is not enough
```

(The non-SSO "no token" message is unchanged apart from a short SSO hint, as a fallback if detection ever misses due to markup drift.)

## Detection is deliberately conservative

It matches signals **specific to the interstitial and scoped to the repo's owner**:
- the owner-scoped `/orgs/<owner>/sso` link, or
- the `<title>Sign in to <owner></title>`.

It intentionally does **not** match the words "SAML"/"single sign-on" appearing anywhere on the page — those live in GitHub's site chrome/help links on virtually every page (and in any repo that's simply *about* SAML), which would be a ~100% false positive. Verified against real captured HTML: a normal repo page and `crewjam/saml` both correctly do **not** match.

## Safety

- Purely additive: the new logic only runs in the existing `match == nil` (no-token) branch. The happy path and all other behavior are unchanged — the only difference is *which error* you get when the upload was already going to fail.
- Owner is regex-quoted; empty owner returns early (no panic, no match).
- Link and title checks are case-insensitive (GitHub owners are case-insensitive and the page may render a different case than the user typed).

## Tests

Adds `internal/upload/token_test.go` (first tests for the package):
- `TestIsSAMLProtected` — true cases + false-positive guards (site chrome, a SAML-about repo, another org's link, substring owner, regex-metachar owner, case-insensitive link, empty owner).
- `TestGetUploadToken` — table-driven via a stubbed `http.RoundTripper`: happy path (token extracted), the SSO error wording, and the generic message.

`go test ./...` and `go vet ./...` pass.