### PR TITLE
Select a live GitHub session cookie across multiple browser stores

### DIFF
--- a/internal/cookies/cookies.go
+++ b/internal/cookies/cookies.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/browserutils/kooky"
 	_ "github.com/browserutils/kooky/browser/brave"
@@ -35,11 +34,10 @@ func NewSessionCookie(value string) *http.Cookie {
 // rawCookie is a github.com cookie reduced to the fields selection needs,
 // decoupled from kooky so the selection logic is unit-testable.
 type rawCookie struct {
-	store    string // FilePath()+"\x00"+Container — identifies one cookie store
-	domain   string
-	name     string
-	value    string
-	creation time.Time
+	store  string // FilePath()+"\x00"+Container — identifies one cookie store
+	domain string
+	name   string
+	value  string
 }
 
 // sessionCandidate is a user_session cookie plus whether its store is logged in.
@@ -47,7 +45,6 @@ type sessionCandidate struct {
 	cookie   *http.Cookie
 	store    string
 	loggedIn bool // a logged_in=yes cookie exists in the SAME store
-	creation time.Time
 }
 
 // readRawCookies reads every valid github.com cookie across all supported
@@ -71,11 +68,10 @@ func readRawCookies() ([]rawCookie, error) {
 			store = c.Browser.FilePath() + "\x00" + c.Container
 		}
 		out = append(out, rawCookie{
-			store:    store,
-			domain:   c.Domain,
-			name:     c.Name,
-			value:    c.Value,
-			creation: c.Creation,
+			store:  store,
+			domain: c.Domain,
+			name:   c.Name,
+			value:  c.Value,
 		})
 	}
 	return out, err
@@ -105,11 +101,11 @@ func groupCandidates(raw []rawCookie) []sessionCandidate {
 		}
 		switch c.name {
 		case "user_session":
-			// Most-recent within a store; on a tie, last-seen wins. Intra-store
-			// ties are effectively impossible (distinct rowids / real timestamps).
-			if s.session == nil || !c.creation.Before(s.session.creation) {
-				s.session = c
-			}
+			// A store essentially never holds two user_session cookies; if it
+			// does, last-seen wins. There's no reliable recency signal to prefer
+			// one (kooky derives Creation from the SQLite rowid on Chromium), and
+			// the final pick across stores is made deterministic in selectSession.
+			s.session = c
 		case "logged_in":
 			if c.value == "yes" {
 				s.loggedIn = true
@@ -126,7 +122,6 @@ func groupCandidates(raw []rawCookie) []sessionCandidate {
 			cookie:   NewSessionCookie(s.session.value),
 			store:    key,
 			loggedIn: s.loggedIn,
-			creation: s.session.creation,
 		})
 	}
 	return out
@@ -149,8 +144,8 @@ func filterLoggedIn(cands []sessionCandidate) []sessionCandidate {
 // remaining tie by validating against GitHub — but only when more than one
 // candidate survives, since a lone candidate is the only choice anyway. It is a
 // picker, not a gate: if validation is inconclusive (all fail, or the network
-// is down) it returns the most-recent candidate and lets the caller surface the
-// authoritative error.
+// is down) it returns the first candidate (by store key) and lets the caller
+// surface the authoritative error.
 func selectSession(cands []sessionCandidate, validate func(*http.Cookie) error) (*http.Cookie, error) {
 	if len(cands) == 0 {
 		return nil, fmt.Errorf("no github.com user_session cookie found in any supported browser — are you logged into GitHub?")
@@ -162,13 +157,11 @@ func selectSession(cands []sessionCandidate, validate func(*http.Cookie) error) 
 	if len(pool) == 0 {
 		pool = append([]sessionCandidate(nil), cands...)
 	}
-	// Creation is a weak signal (rowid-derived, not wall-clock, on Chromium), so
-	// it only orders our attempts; the store key gives a deterministic tiebreak
-	// despite kooky's nondeterministic discovery order.
-	sort.SliceStable(pool, func(i, j int) bool {
-		if !pool[i].creation.Equal(pool[j].creation) {
-			return pool[i].creation.After(pool[j].creation)
-		}
+	// Order by store key for a stable pick across runs (kooky's discovery order
+	// is nondeterministic). There is no trustworthy recency signal to prefer one
+	// store over another, so this order is arbitrary-but-deterministic; when it
+	// matters (2+ live candidates) validation, not ordering, makes the choice.
+	sort.Slice(pool, func(i, j int) bool {
 		return pool[i].store < pool[j].store
 	})
 

--- a/internal/cookies/cookies.go
+++ b/internal/cookies/cookies.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/browserutils/kooky"
 	_ "github.com/browserutils/kooky/browser/brave"
@@ -15,27 +18,185 @@ import (
 	_ "github.com/browserutils/kooky/browser/safari"
 )
 
-// GetGitHubSession returns the user_session cookie for github.com.
-// It searches Chrome, Brave, Edge, Chromium, Firefox, Opera, and Safari (via kooky's
-// registered finders), returning the cookie from the first browser that has one.
-func GetGitHubSession() (*http.Cookie, error) {
+// NewSessionCookie builds a github.com user_session cookie from a raw value.
+// Shape only — it does not trim or validate the value; callers handling
+// user-supplied tokens layer those checks on top.
+func NewSessionCookie(value string) *http.Cookie {
+	return &http.Cookie{
+		Name:     "user_session",
+		Value:    value,
+		Domain:   "github.com",
+		Path:     "/",
+		Secure:   true,
+		HttpOnly: true,
+	}
+}
+
+// rawCookie is a github.com cookie reduced to the fields selection needs,
+// decoupled from kooky so the selection logic is unit-testable.
+type rawCookie struct {
+	store    string // FilePath()+"\x00"+Container — identifies one cookie store
+	domain   string
+	name     string
+	value    string
+	creation time.Time
+}
+
+// sessionCandidate is a user_session cookie plus whether its store is logged in.
+type sessionCandidate struct {
+	cookie   *http.Cookie
+	store    string
+	loggedIn bool // a logged_in=yes cookie exists in the SAME store
+	creation time.Time
+}
+
+// readRawCookies reads every valid github.com cookie across all supported
+// browsers/profiles and reduces each to a rawCookie. It is the only part of
+// selection that touches the real browser stores, so it is kept thin; the
+// ranking logic lives in the pure functions below.
+func readRawCookies() ([]rawCookie, error) {
 	ctx := context.Background()
 
-	cookies, err := kooky.ReadCookies(ctx,
+	// No Name filter: we need logged_in alongside user_session to tell an active
+	// session from a stale logged-out one in the same store.
+	kcookies, err := kooky.ReadCookies(ctx,
 		kooky.Valid,
 		kooky.DomainHasSuffix("github.com"),
-		kooky.Name("user_session"),
 	)
 
-	// kooky returns errors for browsers/profiles that don't exist alongside
-	// cookies from ones that do. Only fail if we got zero cookies.
-	if len(cookies) > 0 {
-		return &cookies[0].Cookie, nil
+	out := make([]rawCookie, 0, len(kcookies))
+	for _, c := range kcookies {
+		store := c.Container
+		if c.Browser != nil {
+			store = c.Browser.FilePath() + "\x00" + c.Container
+		}
+		out = append(out, rawCookie{
+			store:    store,
+			domain:   c.Domain,
+			name:     c.Name,
+			value:    c.Value,
+			creation: c.Creation,
+		})
+	}
+	return out, err
+}
+
+// groupCandidates buckets raw cookies by store and produces one candidate per
+// store that holds a user_session, recording whether that same store is logged
+// in. Only host-only github.com cookies are considered, so subdomain cookies
+// (gist.github.com, …) can't pollute the logged_in correlation.
+func groupCandidates(raw []rawCookie) []sessionCandidate {
+	type store struct {
+		session  *rawCookie
+		loggedIn bool
+	}
+	stores := map[string]*store{}
+	for i := range raw {
+		c := &raw[i]
+		// Host-only github.com only; tolerate a leading-dot domain but still
+		// exclude subdomains (gist.github.com, …) from the logged_in correlation.
+		if strings.TrimPrefix(c.domain, ".") != "github.com" {
+			continue
+		}
+		s := stores[c.store]
+		if s == nil {
+			s = &store{}
+			stores[c.store] = s
+		}
+		switch c.name {
+		case "user_session":
+			// Most-recent within a store; on a tie, last-seen wins. Intra-store
+			// ties are effectively impossible (distinct rowids / real timestamps).
+			if s.session == nil || !c.creation.Before(s.session.creation) {
+				s.session = c
+			}
+		case "logged_in":
+			if c.value == "yes" {
+				s.loggedIn = true
+			}
+		}
 	}
 
-	if err != nil {
-		return nil, fmt.Errorf("reading browser cookies: %w", err)
+	out := make([]sessionCandidate, 0, len(stores))
+	for key, s := range stores {
+		if s.session == nil {
+			continue
+		}
+		out = append(out, sessionCandidate{
+			cookie:   NewSessionCookie(s.session.value),
+			store:    key,
+			loggedIn: s.loggedIn,
+			creation: s.session.creation,
+		})
+	}
+	return out
+}
+
+func filterLoggedIn(cands []sessionCandidate) []sessionCandidate {
+	out := make([]sessionCandidate, 0, len(cands))
+	for _, c := range cands {
+		if c.loggedIn {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// selectSession chooses the best candidate. validate may be nil to skip network
+// validation (an offline, local-only pick).
+//
+// It prefers stores that are actually logged in, then disambiguates any
+// remaining tie by validating against GitHub — but only when more than one
+// candidate survives, since a lone candidate is the only choice anyway. It is a
+// picker, not a gate: if validation is inconclusive (all fail, or the network
+// is down) it returns the most-recent candidate and lets the caller surface the
+// authoritative error.
+func selectSession(cands []sessionCandidate, validate func(*http.Cookie) error) (*http.Cookie, error) {
+	if len(cands) == 0 {
+		return nil, fmt.Errorf("no github.com user_session cookie found in any supported browser — are you logged into GitHub?")
 	}
 
-	return nil, fmt.Errorf("no github.com user_session cookie found in any supported browser — are you logged into GitHub?")
+	// filterLoggedIn allocates; the fallback copies — so we never sort the
+	// caller's slice in place.
+	pool := filterLoggedIn(cands)
+	if len(pool) == 0 {
+		pool = append([]sessionCandidate(nil), cands...)
+	}
+	// Creation is a weak signal (rowid-derived, not wall-clock, on Chromium), so
+	// it only orders our attempts; the store key gives a deterministic tiebreak
+	// despite kooky's nondeterministic discovery order.
+	sort.SliceStable(pool, func(i, j int) bool {
+		if !pool[i].creation.Equal(pool[j].creation) {
+			return pool[i].creation.After(pool[j].creation)
+		}
+		return pool[i].store < pool[j].store
+	})
+
+	if len(pool) == 1 || validate == nil {
+		return pool[0].cookie, nil
+	}
+
+	for _, c := range pool {
+		if validate(c.cookie) == nil {
+			return c.cookie, nil
+		}
+	}
+	return pool[0].cookie, nil
+}
+
+// GetGitHubSession returns the best github.com user_session cookie found across
+// supported browsers. When more than one logged-in candidate exists, validate
+// is used to pick a live one; pass nil to skip network validation.
+func GetGitHubSession(validate func(*http.Cookie) error) (*http.Cookie, error) {
+	raw, err := readRawCookies()
+	cands := groupCandidates(raw)
+	if len(cands) == 0 {
+		// kooky reports errors for absent browsers/profiles alongside cookies
+		// from present ones; only surface the read error if nothing usable came back.
+		if err != nil {
+			return nil, fmt.Errorf("reading browser cookies: %w", err)
+		}
+		return nil, fmt.Errorf("no github.com user_session cookie found in any supported browser — are you logged into GitHub?")
+	}
+	return selectSession(cands, validate)
 }

--- a/internal/cookies/cookies_test.go
+++ b/internal/cookies/cookies_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 )
 
 func TestNewSessionCookie(t *testing.T) {
@@ -21,8 +20,8 @@ func TestNewSessionCookie(t *testing.T) {
 }
 
 // us and li build github.com rawCookies of each kind for a given store.
-func us(store, value string, creation time.Time) rawCookie {
-	return rawCookie{store: store, domain: "github.com", name: "user_session", value: value, creation: creation}
+func us(store, value string) rawCookie {
+	return rawCookie{store: store, domain: "github.com", name: "user_session", value: value}
 }
 func li(store, value string) rawCookie {
 	return rawCookie{store: store, domain: "github.com", name: "logged_in", value: value}
@@ -39,7 +38,7 @@ func candByStore(cands []sessionCandidate, store string) (sessionCandidate, bool
 
 func TestGroupCandidates(t *testing.T) {
 	t.Run("single logged-in store", func(t *testing.T) {
-		got := groupCandidates([]rawCookie{us("A", "tok", time.Time{}), li("A", "yes")})
+		got := groupCandidates([]rawCookie{us("A", "tok"), li("A", "yes")})
 		if len(got) != 1 || !got[0].loggedIn || got[0].cookie.Value != "tok" {
 			t.Fatalf("got %+v, want one logged-in candidate with value tok", got)
 		}
@@ -47,8 +46,8 @@ func TestGroupCandidates(t *testing.T) {
 
 	t.Run("#15 regression: logged-out store not conflated with logged-in one", func(t *testing.T) {
 		got := groupCandidates([]rawCookie{
-			us("A", "active", time.Time{}), li("A", "yes"),
-			us("B", "stale", time.Time{}), // store B is logged out (no logged_in)
+			us("A", "active"), li("A", "yes"),
+			us("B", "stale"), // store B is logged out (no logged_in)
 		})
 		if len(got) != 2 {
 			t.Fatalf("want 2 candidates, got %d", len(got))
@@ -61,7 +60,7 @@ func TestGroupCandidates(t *testing.T) {
 	})
 
 	t.Run("cross-store guard: logged_in in A must not mark B", func(t *testing.T) {
-		got := groupCandidates([]rawCookie{us("A", "a", time.Time{}), li("A", "yes"), us("B", "b", time.Time{})})
+		got := groupCandidates([]rawCookie{us("A", "a"), li("A", "yes"), us("B", "b")})
 		b, _ := candByStore(got, "B")
 		if b.loggedIn {
 			t.Error("store B wrongly marked logged in by store A's logged_in cookie")
@@ -70,7 +69,7 @@ func TestGroupCandidates(t *testing.T) {
 
 	t.Run("logged_in values other than yes are not logged in", func(t *testing.T) {
 		for _, v := range []string{"no", "", "maybe", "Yes"} {
-			got := groupCandidates([]rawCookie{us("A", "t", time.Time{}), li("A", v)})
+			got := groupCandidates([]rawCookie{us("A", "t"), li("A", v)})
 			if got[0].loggedIn {
 				t.Errorf("logged_in=%q should yield loggedIn=false", v)
 			}
@@ -93,20 +92,10 @@ func TestGroupCandidates(t *testing.T) {
 		}
 	})
 
-	t.Run("most-recent user_session per store kept; zero-creation safe", func(t *testing.T) {
-		newer := time.Unix(1000, 0)
-		raw := []rawCookie{us("A", "old", time.Time{}), us("A", "new", newer)}
-		got := groupCandidates(raw)
-		if len(got) != 1 || got[0].cookie.Value != "new" {
-			t.Fatalf("want single candidate with newest value 'new', got %+v", got)
-		}
-	})
-
-	t.Run("equal creation within a store: last-seen wins", func(t *testing.T) {
-		eq := time.Unix(500, 0)
-		got := groupCandidates([]rawCookie{us("A", "first", eq), us("A", "second", eq)})
+	t.Run("multiple user_session in one store: last-seen wins", func(t *testing.T) {
+		got := groupCandidates([]rawCookie{us("A", "first"), us("A", "second")})
 		if len(got) != 1 || got[0].cookie.Value != "second" {
-			t.Fatalf("want last-seen 'second', got %+v", got)
+			t.Fatalf("want single candidate with last-seen value 'second', got %+v", got)
 		}
 	})
 
@@ -139,8 +128,8 @@ func recordingValidator(dead ...string) (func(*http.Cookie) error, *[]string) {
 	}, &calls
 }
 
-func cand(store, value string, loggedIn bool, creation time.Time) sessionCandidate {
-	return sessionCandidate{cookie: NewSessionCookie(value), store: store, loggedIn: loggedIn, creation: creation}
+func cand(store, value string, loggedIn bool) sessionCandidate {
+	return sessionCandidate{cookie: NewSessionCookie(value), store: store, loggedIn: loggedIn}
 }
 
 func TestSelectSession(t *testing.T) {
@@ -152,7 +141,7 @@ func TestSelectSession(t *testing.T) {
 
 	t.Run("single candidate skips validation entirely", func(t *testing.T) {
 		validate, calls := recordingValidator()
-		got, err := selectSession([]sessionCandidate{cand("A", "only", true, time.Time{})}, validate)
+		got, err := selectSession([]sessionCandidate{cand("A", "only", true)}, validate)
 		if err != nil || got.Value != "only" {
 			t.Fatalf("got (%v, %v), want only/nil", got, err)
 		}
@@ -161,59 +150,53 @@ func TestSelectSession(t *testing.T) {
 		}
 	})
 
-	t.Run("nil validator returns most-recent without calls", func(t *testing.T) {
-		older, newer := time.Unix(1, 0), time.Unix(2, 0)
-		got, _ := selectSession([]sessionCandidate{cand("A", "old", true, older), cand("B", "new", true, newer)}, nil)
-		if got.Value != "new" {
-			t.Errorf("got %q, want most-recent 'new'", got.Value)
+	t.Run("nil validator returns first by store key without calls", func(t *testing.T) {
+		got, _ := selectSession([]sessionCandidate{cand("B", "b", true), cand("A", "a", true)}, nil)
+		if got.Value != "a" {
+			t.Errorf("got %q, want first-by-store-key 'a'", got.Value)
 		}
 	})
 
-	t.Run("most-recent valid wins and short-circuits", func(t *testing.T) {
-		older, newer := time.Unix(1, 0), time.Unix(2, 0)
+	t.Run("first valid by store key wins and short-circuits", func(t *testing.T) {
 		validate, calls := recordingValidator()
-		got, _ := selectSession([]sessionCandidate{cand("A", "old", true, older), cand("B", "new", true, newer)}, validate)
-		if got.Value != "new" {
-			t.Errorf("got %q, want 'new'", got.Value)
+		got, _ := selectSession([]sessionCandidate{cand("B", "b", true), cand("A", "a", true)}, validate)
+		if got.Value != "a" {
+			t.Errorf("got %q, want 'a'", got.Value)
 		}
-		if len(*calls) != 1 || (*calls)[0] != "new" {
-			t.Errorf("expected to validate only 'new' then stop; calls=%v", *calls)
+		if len(*calls) != 1 || (*calls)[0] != "a" {
+			t.Errorf("expected to validate only 'a' then stop; calls=%v", *calls)
 		}
 	})
 
-	t.Run("falls through to next when most-recent is dead", func(t *testing.T) {
-		older, newer := time.Unix(1, 0), time.Unix(2, 0)
-		validate, calls := recordingValidator("new") // newest is server-revoked
-		got, _ := selectSession([]sessionCandidate{cand("A", "old", true, older), cand("B", "new", true, newer)}, validate)
-		if got.Value != "old" {
-			t.Errorf("got %q, want the live 'old'", got.Value)
+	t.Run("falls through to next when the first is dead", func(t *testing.T) {
+		validate, calls := recordingValidator("a") // store A's session is server-revoked
+		got, _ := selectSession([]sessionCandidate{cand("A", "a", true), cand("B", "b", true)}, validate)
+		if got.Value != "b" {
+			t.Errorf("got %q, want the live 'b'", got.Value)
 		}
 		if len(*calls) != 2 {
 			t.Errorf("expected to validate both; calls=%v", *calls)
 		}
 	})
 
-	t.Run("all dead falls back to most-recent (picker not gate)", func(t *testing.T) {
-		older, newer := time.Unix(1, 0), time.Unix(2, 0)
-		validate, _ := recordingValidator("old", "new")
-		got, err := selectSession([]sessionCandidate{cand("A", "old", true, older), cand("B", "new", true, newer)}, validate)
-		if err != nil || got.Value != "new" {
-			t.Errorf("got (%q, %v), want most-recent 'new' and no error", got.Value, err)
+	t.Run("all dead falls back to first by store key (picker not gate)", func(t *testing.T) {
+		validate, _ := recordingValidator("a", "b")
+		got, err := selectSession([]sessionCandidate{cand("A", "a", true), cand("B", "b", true)}, validate)
+		if err != nil || got.Value != "a" {
+			t.Errorf("got (%q, %v), want first-by-store-key 'a' and no error", got.Value, err)
 		}
 	})
 
 	t.Run("no logged-in candidates falls back to the full set", func(t *testing.T) {
-		older, newer := time.Unix(1, 0), time.Unix(2, 0)
-		got, _ := selectSession([]sessionCandidate{cand("A", "old", false, older), cand("B", "new", false, newer)}, nil)
-		if got.Value != "new" {
-			t.Errorf("got %q, want 'new' from the full set", got.Value)
+		got, _ := selectSession([]sessionCandidate{cand("B", "b", false), cand("A", "a", false)}, nil)
+		if got.Value != "a" {
+			t.Errorf("got %q, want 'a' from the full set", got.Value)
 		}
 	})
 
-	t.Run("equal creation resolves deterministically by store key", func(t *testing.T) {
-		eq := time.Unix(5, 0)
-		forward := []sessionCandidate{cand("A", "a", true, eq), cand("B", "b", true, eq)}
-		reverse := []sessionCandidate{cand("B", "b", true, eq), cand("A", "a", true, eq)}
+	t.Run("pick is deterministic by store key regardless of input order", func(t *testing.T) {
+		forward := []sessionCandidate{cand("A", "a", true), cand("B", "b", true)}
+		reverse := []sessionCandidate{cand("B", "b", true), cand("A", "a", true)}
 		g1, _ := selectSession(forward, nil)
 		g2, _ := selectSession(reverse, nil)
 		if g1.Value != g2.Value || g1.Value != "a" {

--- a/internal/cookies/cookies_test.go
+++ b/internal/cookies/cookies_test.go
@@ -1,0 +1,223 @@
+package cookies
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestNewSessionCookie(t *testing.T) {
+	c := NewSessionCookie("  raw value  ")
+	if c.Name != "user_session" {
+		t.Errorf("Name = %q, want user_session", c.Name)
+	}
+	if c.Value != "  raw value  " {
+		t.Errorf("Value = %q, want the raw value passed through untrimmed", c.Value)
+	}
+	if c.Domain != "github.com" || c.Path != "/" || !c.Secure || !c.HttpOnly {
+		t.Errorf("unexpected shape: Domain=%q Path=%q Secure=%v HttpOnly=%v", c.Domain, c.Path, c.Secure, c.HttpOnly)
+	}
+}
+
+// us and li build github.com rawCookies of each kind for a given store.
+func us(store, value string, creation time.Time) rawCookie {
+	return rawCookie{store: store, domain: "github.com", name: "user_session", value: value, creation: creation}
+}
+func li(store, value string) rawCookie {
+	return rawCookie{store: store, domain: "github.com", name: "logged_in", value: value}
+}
+
+func candByStore(cands []sessionCandidate, store string) (sessionCandidate, bool) {
+	for _, c := range cands {
+		if c.store == store {
+			return c, true
+		}
+	}
+	return sessionCandidate{}, false
+}
+
+func TestGroupCandidates(t *testing.T) {
+	t.Run("single logged-in store", func(t *testing.T) {
+		got := groupCandidates([]rawCookie{us("A", "tok", time.Time{}), li("A", "yes")})
+		if len(got) != 1 || !got[0].loggedIn || got[0].cookie.Value != "tok" {
+			t.Fatalf("got %+v, want one logged-in candidate with value tok", got)
+		}
+	})
+
+	t.Run("#15 regression: logged-out store not conflated with logged-in one", func(t *testing.T) {
+		got := groupCandidates([]rawCookie{
+			us("A", "active", time.Time{}), li("A", "yes"),
+			us("B", "stale", time.Time{}), // store B is logged out (no logged_in)
+		})
+		if len(got) != 2 {
+			t.Fatalf("want 2 candidates, got %d", len(got))
+		}
+		a, _ := candByStore(got, "A")
+		b, _ := candByStore(got, "B")
+		if !a.loggedIn || b.loggedIn {
+			t.Errorf("loggedIn flags wrong: A=%v (want true) B=%v (want false)", a.loggedIn, b.loggedIn)
+		}
+	})
+
+	t.Run("cross-store guard: logged_in in A must not mark B", func(t *testing.T) {
+		got := groupCandidates([]rawCookie{us("A", "a", time.Time{}), li("A", "yes"), us("B", "b", time.Time{})})
+		b, _ := candByStore(got, "B")
+		if b.loggedIn {
+			t.Error("store B wrongly marked logged in by store A's logged_in cookie")
+		}
+	})
+
+	t.Run("logged_in values other than yes are not logged in", func(t *testing.T) {
+		for _, v := range []string{"no", "", "maybe", "Yes"} {
+			got := groupCandidates([]rawCookie{us("A", "t", time.Time{}), li("A", v)})
+			if got[0].loggedIn {
+				t.Errorf("logged_in=%q should yield loggedIn=false", v)
+			}
+		}
+	})
+
+	t.Run("logged_in without user_session yields no candidate", func(t *testing.T) {
+		if got := groupCandidates([]rawCookie{li("A", "yes")}); len(got) != 0 {
+			t.Errorf("want no candidates, got %d", len(got))
+		}
+	})
+
+	t.Run("subdomain cookies are ignored", func(t *testing.T) {
+		raw := []rawCookie{
+			{store: "A", domain: "gist.github.com", name: "user_session", value: "sub"},
+			{store: "A", domain: "gist.github.com", name: "logged_in", value: "yes"},
+		}
+		if got := groupCandidates(raw); len(got) != 0 {
+			t.Errorf("subdomain cookies must not produce a github.com candidate, got %d", len(got))
+		}
+	})
+
+	t.Run("most-recent user_session per store kept; zero-creation safe", func(t *testing.T) {
+		newer := time.Unix(1000, 0)
+		raw := []rawCookie{us("A", "old", time.Time{}), us("A", "new", newer)}
+		got := groupCandidates(raw)
+		if len(got) != 1 || got[0].cookie.Value != "new" {
+			t.Fatalf("want single candidate with newest value 'new', got %+v", got)
+		}
+	})
+
+	t.Run("equal creation within a store: last-seen wins", func(t *testing.T) {
+		eq := time.Unix(500, 0)
+		got := groupCandidates([]rawCookie{us("A", "first", eq), us("A", "second", eq)})
+		if len(got) != 1 || got[0].cookie.Value != "second" {
+			t.Fatalf("want last-seen 'second', got %+v", got)
+		}
+	})
+
+	t.Run("leading-dot github.com domain is accepted; subdomain still rejected", func(t *testing.T) {
+		raw := []rawCookie{
+			{store: "A", domain: ".github.com", name: "user_session", value: "dot"},
+			{store: "A", domain: ".github.com", name: "logged_in", value: "yes"},
+		}
+		got := groupCandidates(raw)
+		if len(got) != 1 || got[0].cookie.Value != "dot" || !got[0].loggedIn {
+			t.Fatalf("want one logged-in candidate from .github.com, got %+v", got)
+		}
+	})
+}
+
+// recordingValidator returns a validator that fails for any cookie whose value
+// is in dead, succeeds otherwise, and records the order of values it was asked about.
+func recordingValidator(dead ...string) (func(*http.Cookie) error, *[]string) {
+	deadSet := map[string]bool{}
+	for _, d := range dead {
+		deadSet[d] = true
+	}
+	var calls []string
+	return func(c *http.Cookie) error {
+		calls = append(calls, c.Value)
+		if deadSet[c.Value] {
+			return fmt.Errorf("token is invalid or expired")
+		}
+		return nil
+	}, &calls
+}
+
+func cand(store, value string, loggedIn bool, creation time.Time) sessionCandidate {
+	return sessionCandidate{cookie: NewSessionCookie(value), store: store, loggedIn: loggedIn, creation: creation}
+}
+
+func TestSelectSession(t *testing.T) {
+	t.Run("empty is an error", func(t *testing.T) {
+		if _, err := selectSession(nil, nil); err == nil {
+			t.Error("expected error for empty candidates")
+		}
+	})
+
+	t.Run("single candidate skips validation entirely", func(t *testing.T) {
+		validate, calls := recordingValidator()
+		got, err := selectSession([]sessionCandidate{cand("A", "only", true, time.Time{})}, validate)
+		if err != nil || got.Value != "only" {
+			t.Fatalf("got (%v, %v), want only/nil", got, err)
+		}
+		if len(*calls) != 0 {
+			t.Errorf("validate must not be called for a single candidate; calls=%v", *calls)
+		}
+	})
+
+	t.Run("nil validator returns most-recent without calls", func(t *testing.T) {
+		older, newer := time.Unix(1, 0), time.Unix(2, 0)
+		got, _ := selectSession([]sessionCandidate{cand("A", "old", true, older), cand("B", "new", true, newer)}, nil)
+		if got.Value != "new" {
+			t.Errorf("got %q, want most-recent 'new'", got.Value)
+		}
+	})
+
+	t.Run("most-recent valid wins and short-circuits", func(t *testing.T) {
+		older, newer := time.Unix(1, 0), time.Unix(2, 0)
+		validate, calls := recordingValidator()
+		got, _ := selectSession([]sessionCandidate{cand("A", "old", true, older), cand("B", "new", true, newer)}, validate)
+		if got.Value != "new" {
+			t.Errorf("got %q, want 'new'", got.Value)
+		}
+		if len(*calls) != 1 || (*calls)[0] != "new" {
+			t.Errorf("expected to validate only 'new' then stop; calls=%v", *calls)
+		}
+	})
+
+	t.Run("falls through to next when most-recent is dead", func(t *testing.T) {
+		older, newer := time.Unix(1, 0), time.Unix(2, 0)
+		validate, calls := recordingValidator("new") // newest is server-revoked
+		got, _ := selectSession([]sessionCandidate{cand("A", "old", true, older), cand("B", "new", true, newer)}, validate)
+		if got.Value != "old" {
+			t.Errorf("got %q, want the live 'old'", got.Value)
+		}
+		if len(*calls) != 2 {
+			t.Errorf("expected to validate both; calls=%v", *calls)
+		}
+	})
+
+	t.Run("all dead falls back to most-recent (picker not gate)", func(t *testing.T) {
+		older, newer := time.Unix(1, 0), time.Unix(2, 0)
+		validate, _ := recordingValidator("old", "new")
+		got, err := selectSession([]sessionCandidate{cand("A", "old", true, older), cand("B", "new", true, newer)}, validate)
+		if err != nil || got.Value != "new" {
+			t.Errorf("got (%q, %v), want most-recent 'new' and no error", got.Value, err)
+		}
+	})
+
+	t.Run("no logged-in candidates falls back to the full set", func(t *testing.T) {
+		older, newer := time.Unix(1, 0), time.Unix(2, 0)
+		got, _ := selectSession([]sessionCandidate{cand("A", "old", false, older), cand("B", "new", false, newer)}, nil)
+		if got.Value != "new" {
+			t.Errorf("got %q, want 'new' from the full set", got.Value)
+		}
+	})
+
+	t.Run("equal creation resolves deterministically by store key", func(t *testing.T) {
+		eq := time.Unix(5, 0)
+		forward := []sessionCandidate{cand("A", "a", true, eq), cand("B", "b", true, eq)}
+		reverse := []sessionCandidate{cand("B", "b", true, eq), cand("A", "a", true, eq)}
+		g1, _ := selectSession(forward, nil)
+		g2, _ := selectSession(reverse, nil)
+		if g1.Value != g2.Value || g1.Value != "a" {
+			t.Errorf("nondeterministic tiebreak: %q vs %q (want both 'a')", g1.Value, g2.Value)
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -247,8 +247,16 @@ func classifySubcommand(imagePaths []string, firstPosAfterDoubleDash bool, token
 
 // resolveSessionCookie returns a GitHub session cookie using the first available
 // source: --token flag, GH_SESSION_TOKEN environment variable, or browser extraction.
+// The browser getter validates candidates against GitHub when more than one
+// logged-in session exists, so a stale/logged-out cookie isn't picked over a live one.
 func resolveSessionCookie(tokenFlag string) (*http.Cookie, string, error) {
-	return resolveSessionCookieWithGetter(tokenFlag, os.Getenv("GH_SESSION_TOKEN"), cookies.GetGitHubSession)
+	get := func() (*http.Cookie, error) {
+		return cookies.GetGitHubSession(func(c *http.Cookie) error {
+			_, err := session.CheckValidity(c)
+			return err
+		})
+	}
+	return resolveSessionCookieWithGetter(tokenFlag, os.Getenv("GH_SESSION_TOKEN"), get)
 }
 
 // resolveSessionCookieWithGetter is a testable variant of resolveSessionCookie
@@ -285,14 +293,7 @@ func cookieFromValue(value string) (*http.Cookie, error) {
 	if value == "" {
 		return nil, fmt.Errorf("session token is empty")
 	}
-	return &http.Cookie{
-		Name:     "user_session",
-		Value:    value,
-		Domain:   "github.com",
-		Path:     "/",
-		Secure:   true,
-		HttpOnly: true,
-	}, nil
+	return cookies.NewSessionCookie(value), nil
 }
 
 // extractToken extracts a session token from the browser and returns the raw value.
@@ -307,7 +308,8 @@ func extractToken(getBrowserCookie func() (*http.Cookie, error)) (string, error)
 // handleExtractToken extracts the session cookie from the browser and prints
 // the raw token value to stdout. Source info is written to stderr.
 func handleExtractToken() {
-	value, err := extractToken(cookies.GetGitHubSession)
+	// extract-token stays offline: pass nil so selection skips network validation.
+	value, err := extractToken(func() (*http.Cookie, error) { return cookies.GetGitHubSession(nil) })
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
## Problem

`cookies.GetGitHubSession` read every `user_session` cookie across all browsers/profiles via kooky (filtered only by **expiry**) and returned `cookies[0]` — the first in kooky's nondeterministic store-discovery order. When more than one cookie store holds an unexpired `user_session` (multiple profiles in *any* browser, multiple browsers installed, or Firefox containers — **not** Firefox-specific), a stale/logged-out cookie can win. It passes expiry checks but fails on use: the repo page returns no `uploadToken`; `check-token` returns 302.

Closes #15.

## Change

Selection now:
1. **Gathers** all `user_session` candidates with per-store identity (`FilePath()` + `Container`), scoped to host-only `github.com`.
2. **Prefers** candidates whose *same store* has `logged_in=yes` (GitHub sets it on login, removes it on logout) — a free, local, browser-agnostic signal that alone fixes the reported scenario.
3. **Validates only to disambiguate:** with a single candidate it's used as-is (if dead, the upload fails the same as before — a request buys nothing); with 2+ logged-in candidates it validates against GitHub and takes the first live one. This closes the server-side-revocation gap that `logged_in=yes` can't catch.

It's a **picker, not a gate**: if validation is inconclusive (all fail, or offline), it returns the first candidate (by store key) and lets the caller surface the authoritative error. `check-token` remains the explicit validity gate.

Validation is **injected** (`validate func(*http.Cookie) error`) because `internal/session` imports `internal/cookies`, so `cookies` can't import `session`. `extract-token` passes `nil` to stay offline.

## Notes
- `--token` / `GH_SESSION_TOKEN` bypass `GetGitHubSession` entirely and are unaffected.
- Selection deliberately ignores cookie **recency**: kooky derives `Creation` from the SQLite rowid on the Chromium family (a real cookie's creation reads back as the year 2185), so it's a false signal. Candidates are ordered by **store key alone** — deterministic across kooky's nondeterministic discovery order — and validation, not recency, chooses among multiple live candidates.
- Out of scope (noted on the issue): a `--browser`/`--profile` flag, a multi-account warning, and a clearer logged-out error message.

## Tests
Adds `internal/cookies/cookies_test.go` (the package's first cookie tests) over a pure, kooky-free core — real structs + a stub validator func, no kooky/HTTP mocks. Covers the #15 regression, cross-store correlation guard, subdomain exclusion, `logged_in` value handling, and the full `selectSession` decision matrix (single-skips-validation, short-circuit, fall-through, all-dead fallback, determinism). `go build/vet`, `go test -race -cover ./...` all pass.

Verified end-to-end against real browser cookies: `logged_in` is read from a live Chrome store, the per-store correlation works, and `check-token` resolves + validates the session.