### PR TITLE
Add an Agent Skill (SKILL.md) so gh-image is installable via npx skills add

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ gh extension install drogers0/gh-image
 
 That's it. The [`gh` CLI](https://cli.github.com) auto-detects your platform and downloads the prebuilt binary. Pre-built releases ship for **macOS** (arm64, amd64), **Linux** (amd64, arm64), and **Windows** (amd64).
 
-> **Using an AI agent?** `gh-image` is also packaged as an [agent skill](https://agentskills.io): `npx skills add drogers0/gh-image` makes it available to Claude Code, Codex, and other skills-compatible agents.
+> **Using an AI agent?** `gh-image` is also packaged as an [agent skill](https://agentskills.io). Run `npx skills add drogers0/gh-image` to make it available to your agent — the [Agent Skills standard](https://agentskills.io/clients) is supported by **Claude Code**, **OpenAI Codex**, **Cursor**, **GitHub Copilot**, and many others — so you can just ask it to "attach this screenshot to the PR."
 
 <details>
 <summary>Build from source</summary>

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ gh extension install drogers0/gh-image
 
 That's it. The [`gh` CLI](https://cli.github.com) auto-detects your platform and downloads the prebuilt binary. Pre-built releases ship for **macOS** (arm64, amd64), **Linux** (amd64, arm64), and **Windows** (amd64).
 
-> **Using an AI agent?** `gh-image` is also packaged as an [agent skill](https://agentskills.io). Run `npx skills add drogers0/gh-image` to make it available to your agent — the [Agent Skills standard](https://agentskills.io/clients) is supported by **Claude Code**, **OpenAI Codex**, **Cursor**, **GitHub Copilot**, and many others — so you can just ask it to "attach this screenshot to the PR."
-
 <details>
 <summary>Build from source</summary>
 
@@ -83,6 +81,16 @@ $(gh image bug.png)
 
 Happens consistently after the third click."
 ```
+
+## Use with AI agents
+
+`gh-image` is packaged as an [agent skill](https://agentskills.io), so AI coding agents can upload and embed images for you — just ask in natural language, e.g. *"attach this screenshot to the PR"* or *"file an issue and add this image."*
+
+```bash
+npx skills add drogers0/gh-image
+```
+
+The open [Agent Skills standard](https://agentskills.io/clients) is supported by **Claude Code**, **OpenAI Codex**, **Cursor**, **GitHub Copilot**, and [many more](https://agentskills.io/clients). The skill walks the agent through installing this extension (if needed), running the upload, and embedding the resulting `user-attachments` URL into a PR, issue, or comment.
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   <a href="https://github.com/drogers0/gh-image/releases"><img src="https://img.shields.io/github/downloads/drogers0/gh-image/total?color=green" alt="Total downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/drogers0/gh-image?color=lightgrey" alt="License: MIT"></a>
   <a href="https://goreportcard.com/report/github.com/drogers0/gh-image"><img src="https://goreportcard.com/badge/github.com/drogers0/gh-image" alt="Go Report Card"></a>
+  <a href="https://skills.sh/drogers0/gh-image"><img src="https://skills.sh/b/drogers0/gh-image" alt="skills.sh"></a>
 </p>
 
 ---
@@ -30,6 +31,8 @@ gh extension install drogers0/gh-image
 ```
 
 That's it. The [`gh` CLI](https://cli.github.com) auto-detects your platform and downloads the prebuilt binary. Pre-built releases ship for **macOS** (arm64, amd64), **Linux** (amd64, arm64), and **Windows** (amd64).
+
+> **Using an AI agent?** `gh-image` is also packaged as an [agent skill](https://agentskills.io): `npx skills add drogers0/gh-image` makes it available to Claude Code, Codex, and other skills-compatible agents.
 
 <details>
 <summary>Build from source</summary>

--- a/skills/github-image-upload/SKILL.md
+++ b/skills/github-image-upload/SKILL.md
@@ -119,7 +119,8 @@ To control display size, embed an HTML tag instead of the bare markdown:
 
 | Symptom | Cause / fix |
 |---|---|
-| `uploadToken not found … do you have write access?` | Often a **SAML SSO org**: your session isn't SSO-authorized. Authorize at `https://github.com/orgs/<org>/sso`, then retry. Write access alone is not enough. |
+| `<org> enforces SAML SSO and your session is not authorized…` | The org requires SSO and your session isn't authorized. Open the `https://github.com/orgs/<org>/sso` URL from the message in a browser, authorize (lasts ~24h), then retry. Write access alone is not enough — this is not a permissions problem. |
+| `uploadToken not found … do you have write access?` | The generic no-token case. Confirm you have write access; if the repo's org uses SSO, authorize at `https://github.com/orgs/<org>/sso` (the message includes this hint) and retry. |
 | No `user_session` cookie found | Log into GitHub in a supported browser, or set `GH_SESSION_TOKEN`. |
 | Windows + Chrome 127+ can't read cookies | Known cookie-library limitation — use another browser or `GH_SESSION_TOKEN`. |
 | CI / headless run | Set `GH_SESSION_TOKEN` (dedicated bot account); the browser cookie path won't exist. |

--- a/skills/github-image-upload/SKILL.md
+++ b/skills/github-image-upload/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: github-image-upload
+description: >-
+  Upload local images to GitHub and embed them in a pull request description, an
+  issue, or a comment — producing canonical github.com/user-attachments URLs
+  (private-repo images stay private). Use when asked to "attach a screenshot to
+  the PR", "add an image to the PR description", "put this image in the issue",
+  "show test results in the PR", "embed before/after screenshots", or any request
+  to visually document changes on GitHub. Powered by the `gh-image` gh CLI
+  extension.
+license: MIT
+---
+
+# Upload images to GitHub (gh-image)
+
+GitHub has **no public API** for image uploads — the web UI uses an internal
+endpoint that mints `user-attachments` URLs scoped to the repo's visibility.
+[`gh-image`](https://github.com/drogers0/gh-image) (MIT, © drogers0) replicates
+that flow as a `gh` CLI extension, so you can upload from the terminal and get a
+ready-to-embed `![name](url)` back.
+
+This skill drives `gh-image` and then embeds the result into a PR/issue/comment.
+
+## Prerequisites — verify these before uploading
+
+Run these checks; only act on the ones that fail.
+
+1. **`gh` CLI installed & authenticated**
+
+   ```bash
+   gh auth status
+   ```
+   If it fails, tell the user to run `gh auth login` (do not attempt it unattended).
+
+2. **The `gh-image` extension installed** (idempotent — skip if already present)
+
+   ```bash
+   gh extension list | grep -q 'drogers0/gh-image' || gh extension install drogers0/gh-image
+   ```
+
+3. **A GitHub session for the upload.** `gh-image` does NOT use the `gh` token for
+   the upload (that endpoint rejects tokens); it needs the browser `user_session`
+   cookie. Resolution order (first match wins):
+   - `--token <value>` flag, or
+   - `GH_SESSION_TOKEN` env var (use this in CI / headless), or
+   - the cookie store of a logged-in browser (Chrome/Brave/Chromium/Edge/Firefox/
+     Opera/Safari) — the default for local use. On macOS the first read may show a
+     Keychain prompt; the user should click **Always Allow**.
+
+   > ⚠️ A `user_session` cookie grants **full account access** (it is not scoped
+   > like a PAT). Treat it like a password; in CI use a dedicated bot account.
+
+## Step 1 — Normalize the image path
+
+Use an **absolute path**. If a glob is given, resolve it first. Paths with spaces
+or Unicode (e.g. CleanShot's narrow spaces) work, but quote them.
+
+## Step 2 — Upload
+
+```bash
+# One or more images; --repo is optional inside a repo working dir (inferred from the remote).
+gh image "/abs/path/screenshot.png" --repo <owner>/<repo>
+```
+
+`gh image` prints markdown to **stdout**, e.g.:
+
+```
+![screenshot.png](https://github.com/user-attachments/assets/<uuid>)
+```
+
+Capture that output — it is the embeddable reference. For multiple files it prints
+one line per image.
+
+## Step 3 — Embed into the PR / issue / comment
+
+`gh-image` only prints the markdown; you embed it. Pick the target the user asked for.
+
+**Append to a PR description** (preserves the existing body):
+
+```bash
+MD="$(gh image "/abs/path/shot.png" --repo owner/repo)"
+BODY="$(gh pr view <pr> --repo owner/repo --json body -q .body)"
+printf '%s\n\n## Screenshots\n\n%s\n' "$BODY" "$MD" \
+  | gh pr edit <pr> --repo owner/repo --body-file -
+```
+
+**Post as a new PR comment:**
+
+```bash
+MD="$(gh image "/abs/path/shot.png" --repo owner/repo)"
+printf '## Screenshots\n\n%s\n' "$MD" | gh pr comment <pr> --repo owner/repo --body-file -
+```
+
+**Add to an issue body / comment:** same pattern with `gh issue edit <n> --body-file -`
+or `gh issue comment <n> --body-file -`.
+
+Always use `--body-file -` (not inline `--body`) so multi-line bodies and special
+characters can't break shell quoting.
+
+## Step 4 — Verify
+
+```bash
+gh pr view <pr> --repo owner/repo --json body -q .body   # confirm the URL is present
+```
+
+The `user-attachments` URL inherits the repo's visibility, so on a **private** repo
+it renders only for authorized viewers (an anonymous fetch returns 404/403 — that is
+expected, not a failure).
+
+## Sizing (optional)
+
+To control display size, embed an HTML tag instead of the bare markdown:
+
+```html
+<img width="800" alt="screenshot" src="https://github.com/user-attachments/assets/<uuid>" />
+```
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `uploadToken not found … do you have write access?` | Often a **SAML SSO org**: your session isn't SSO-authorized. Authorize at `https://github.com/orgs/<org>/sso`, then retry. Write access alone is not enough. |
+| No `user_session` cookie found | Log into GitHub in a supported browser, or set `GH_SESSION_TOKEN`. |
+| Windows + Chrome 127+ can't read cookies | Known cookie-library limitation — use another browser or `GH_SESSION_TOKEN`. |
+| CI / headless run | Set `GH_SESSION_TOKEN` (dedicated bot account); the browser cookie path won't exist. |
+| `gh: command not found` | Install the GitHub CLI (`brew install gh`, etc.). |


### PR DESCRIPTION
## What

Adds `skills/github-image-upload/SKILL.md` — an [Agent Skill](https://agentskills.io) that packages `gh-image` for AI coding agents.

With this, `gh-image` becomes installable as a cross-agent skill:

```bash
npx skills add drogers0/gh-image
```

The Agent Skills (SKILL.md) standard is consumed natively by **Claude Code**, **OpenAI Codex**, and ~40 other agents — so this gives `gh-image` an agent-native entry point and a listing on [skills.sh](https://skills.sh) (ranked by install telemetry, no submission step).

## Why

`gh-image` is a great primitive, but an agent doesn't know it exists or how to use it. The skill provides the procedural knowledge: it walks the agent through the prerequisites, the upload, and embedding the result — so a user can just say *"attach this screenshot to the PR"* (or issue/comment) and it works.

## What the skill does

- **Prerequisites** (checked, idempotent): `gh auth status`; install the extension only if missing (`gh extension list | grep -q drogers0/gh-image || gh extension install drogers0/gh-image`); explains the `user_session` cookie / `GH_SESSION_TOKEN` auth model, with the full-account-cookie security caveat.
- **Upload**: `gh image <file> --repo owner/repo` and capture the `![name](url)` it prints.
- **Embed**: splice the URL into a PR description, PR comment, or issue via `gh ... --body-file -` (quoting-safe).
- **Verify** + optional `<img width>` sizing.
- **Troubleshooting** table, including the SAML-SSO case (authorize at `/orgs/<org>/sso`), the Windows + Chrome 127+ note, and the CI/headless `GH_SESSION_TOKEN` path — all mirroring the README.

It's instruction-only (no bundled binary): the skill tells the agent to `gh extension install drogers0/gh-image`, so there's nothing to rebuild per release.

## Tested

Installed from a fork branch (`npx skills add mxschmitt/gh-image#agent-skill`) and exercised end-to-end in an agent: *"take a screenshot, file a GitHub issue, and upload the image to it"* — worked. The skills CLI parses the frontmatter and lists it correctly:

```
◇  Found 1 skill
│    github-image-upload
│      Upload local images to GitHub and embed them in a pull request description, an issue, or a comment …
```

MIT-licensed to match the repo. Happy to adjust the wording/scope however you'd prefer.