### PR TITLE
Add test seams at I/O boundaries to raise coverage to ~90%

### DIFF
--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -15,6 +15,7 @@ gh-image/
 ├── internal/
 │   ├── cookies/
 │   │   ├── cookies.go               # Browser session cookie extraction via kooky
+│   │   ├── cookies_test.go
 │   │   ├── jar.go                   # GitHub cookie jar + same-site pair construction
 │   │   └── jar_test.go
 │   ├── session/
@@ -24,10 +25,13 @@ gh-image/
 │   │   └── httputil.go              # Shared User-Agent constant
 │   ├── upload/
 │   │   ├── upload.go                # Orchestrates the 3-step upload flow + HTTP client
+│   │   ├── upload_test.go
 │   │   ├── token.go                 # Fetches uploadToken from repo page
+│   │   ├── token_test.go
 │   │   └── s3.go                    # S3 presigned multipart upload
 │   └── repo/
-│       └── repo.go                  # Infers owner/repo from git remote, resolves repo ID
+│       ├── repo.go                  # Infers owner/repo from git remote, resolves repo ID
+│       └── repo_test.go
 ├── documentation/
 │   ├── architecture.md              # This file
 │   └── github-image-upload-flow.md  # Reverse-engineered upload protocol
@@ -70,13 +74,14 @@ Reads the GitHub `user_session` cookie from local browser cookie stores.
 - AES decryption and cookie DB schema differences across versions
 - Per-browser quirks for Chromium-family browsers, Firefox, Safari, and Opera
 
-**Supported browsers** (registered via blank-imported kooky finders): Chrome, Brave, Edge, Chromium, Firefox, Opera, Safari. `GetGitHubSession` queries all of them in one pass and returns the first valid `user_session` cookie found.
+**Supported browsers** (registered via blank-imported kooky finders): Chrome, Brave, Edge, Chromium, Firefox, Opera, Safari. `GetGitHubSession` queries all of them in one pass, groups the `user_session` candidates per browser store, and prefers stores that are logged in. When more than one candidate survives, `validate` is used to pick a live one (pass nil to skip network validation).
 
 ```go
-// GetGitHubSession returns the user_session cookie for github.com.
-// It searches all registered browsers in one pass and returns the cookie
-// from the first browser that has one.
-func GetGitHubSession() (*http.Cookie, error)
+// GetGitHubSession returns the best user_session cookie for github.com across
+// all registered browsers. It groups candidates per browser store, prefers
+// stores that are logged in, and when more than one survives uses validate to
+// pick a live one (pass nil to skip network validation).
+func GetGitHubSession(validate func(*http.Cookie) error) (*http.Cookie, error)
 ```
 
 The only cookie that needs to be read from the browser is `user_session`. The `__Host-user_session_same_site` cookie is a strict-SameSite duplicate with the same value, so it is synthesized rather than read separately (see Cookie Jar below). The `_gh_sess` cookie rotates with each GitHub response and is managed automatically by the HTTP client's cookie jar.
@@ -119,14 +124,14 @@ If `--repo` is not provided, the tool infers `owner/repo` from the current git w
 
 The numeric repository ID is resolved via the GitHub REST API (`gh api repos/{owner}/{repo} --jq .id`).
 
+The `git`/`gh` calls go through an injectable command `runner` (the exported
+`Resolve` wraps the production `execRun`), so remote-URL and ID parsing are
+unit-testable without a real git repo or authenticated `gh`.
+
 ```go
-// FromRemote infers the GitHub owner/repo from the git remote in the current directory.
-func FromRemote() (owner, name string, err error)
-
-// LookupID resolves the numeric repository ID via the gh CLI.
-func LookupID(owner, name string) (int, error)
-
-// Resolve returns full repo info. If owner/name are empty, it infers from the git remote.
+// Resolve returns full repo info. If owner/name are empty, it infers from the
+// git remote. Internally it delegates to unexported workers (fromRemote,
+// lookupID, resolve) that take an injectable command runner.
 func Resolve(owner, name string) (*Info, error)
 ```
 
@@ -134,13 +139,18 @@ func Resolve(owner, name string) (*Info, error)
 
 Implements the 3-step upload protocol documented in [github-image-upload-flow.md](github-image-upload-flow.md). All GitHub-bound requests use a shared `http.Client` whose cookie jar is built by `cookies.NewGitHubCookieJar`, so `_gh_sess` rotation is handled automatically.
 
+All GitHub requests are issued through a `*Client` that carries the cookie-jar
+HTTP client plus a `baseURL` (production `https://github.com`); tests point
+`baseURL` at an `httptest` server to exercise the real request/parse code.
+
 ```go
-// NewClient creates an http.Client with the GitHub session cookies set.
-func NewClient(sessionCookie *http.Cookie) *http.Client
+// NewClient creates a Client with the GitHub session cookies set and the
+// production base URL.
+func NewClient(sessionCookie *http.Cookie) *Client
 
 // Upload uploads an image file to GitHub and returns the asset URL,
 // sanitized filename, and a ready-to-paste markdown reference.
-func Upload(client *http.Client, owner, repo string, repoID int, imagePath string) (*Result, error)
+func (c *Client) Upload(owner, repo string, repoID int, imagePath string) (*Result, error)
 ```
 
 #### Token Retrieval (`token.go`)
@@ -148,9 +158,9 @@ func Upload(client *http.Client, owner, repo string, repoID int, imagePath strin
 Fetches the repository page and extracts the `uploadToken` from the embedded JavaScript payload. This token is specific to the upload endpoint — standard form CSRF tokens do not work.
 
 ```go
-// GetUploadToken fetches the repo page and extracts the uploadToken
+// getUploadToken fetches the repo page and extracts the uploadToken
 // from the JS payload. Requires authenticated cookies in the client.
-func GetUploadToken(client *http.Client, owner, repo string) (string, error)
+func (c *Client) getUploadToken(owner, repo string) (string, error)
 ```
 
 #### Upload Orchestration (`upload.go`)
@@ -158,7 +168,7 @@ func GetUploadToken(client *http.Client, owner, repo string) (string, error)
 Coordinates the full flow for a single image:
 
 ```
-GetUploadToken()
+Get upload token
         │
         ▼
 requestPolicy()        ──→  POST /upload/policies/assets
@@ -187,6 +197,13 @@ finalizeUpload()       ──→  PUT /upload/assets/{asset_id}
 Handles the multipart form construction for the S3 presigned upload. Separated from the main orchestration because the S3 request has different requirements (no cookies, no GitHub headers, just the presigned form fields and file data).
 
 ### 7. CLI Entrypoint (`main.go`)
+
+`main()` is a one-line entrypoint that delegates to a testable
+`run(args []string, stdout, stderr io.Writer, deps) int`: it returns an exit code
+instead of calling `os.Exit`, writes to injected streams, and takes its I/O
+boundaries (repo resolution, cookie resolution, upload, extract-token, check-token)
+as a `deps` struct, so the full CLI spine is exercised in tests without network,
+subprocess, or process exit.
 
 Responsibilities:
 

--- a/internal/cookies/cookies.go
+++ b/internal/cookies/cookies.go
@@ -60,7 +60,13 @@ func readRawCookies() ([]rawCookie, error) {
 		kooky.Valid,
 		kooky.DomainHasSuffix("github.com"),
 	)
+	return mapKookyCookies(kcookies), err
+}
 
+// mapKookyCookies reduces kooky cookies to the fields selection needs. It is split
+// from readRawCookies so the (pure) store-key derivation is unit-testable without
+// touching real browser stores.
+func mapKookyCookies(kcookies []*kooky.Cookie) []rawCookie {
 	out := make([]rawCookie, 0, len(kcookies))
 	for _, c := range kcookies {
 		store := c.Container
@@ -74,7 +80,7 @@ func readRawCookies() ([]rawCookie, error) {
 			value:  c.Value,
 		})
 	}
-	return out, err
+	return out
 }
 
 // groupCandidates buckets raw cookies by store and produces one candidate per
@@ -177,19 +183,26 @@ func selectSession(cands []sessionCandidate, validate func(*http.Cookie) error) 
 	return pool[0].cookie, nil
 }
 
+// chooseSession turns a raw cookie read (and any read error) into the selected
+// session cookie. Splitting this from readRawCookies keeps the kooky browser read
+// the only part of the package that isn't unit-testable.
+func chooseSession(raw []rawCookie, readErr error, validate func(*http.Cookie) error) (*http.Cookie, error) {
+	cands := groupCandidates(raw)
+	if len(cands) == 0 {
+		// kooky reports errors for absent browsers/profiles alongside cookies
+		// from present ones; only surface the read error if nothing usable came back.
+		if readErr != nil {
+			return nil, fmt.Errorf("reading browser cookies: %w", readErr)
+		}
+		return nil, fmt.Errorf("no github.com user_session cookie found in any supported browser — are you logged into GitHub?")
+	}
+	return selectSession(cands, validate)
+}
+
 // GetGitHubSession returns the best github.com user_session cookie found across
 // supported browsers. When more than one logged-in candidate exists, validate
 // is used to pick a live one; pass nil to skip network validation.
 func GetGitHubSession(validate func(*http.Cookie) error) (*http.Cookie, error) {
 	raw, err := readRawCookies()
-	cands := groupCandidates(raw)
-	if len(cands) == 0 {
-		// kooky reports errors for absent browsers/profiles alongside cookies
-		// from present ones; only surface the read error if nothing usable came back.
-		if err != nil {
-			return nil, fmt.Errorf("reading browser cookies: %w", err)
-		}
-		return nil, fmt.Errorf("no github.com user_session cookie found in any supported browser — are you logged into GitHub?")
-	}
-	return selectSession(cands, validate)
+	return chooseSession(raw, err, validate)
 }

--- a/internal/cookies/cookies_test.go
+++ b/internal/cookies/cookies_test.go
@@ -3,8 +3,38 @@ package cookies
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/browserutils/kooky"
 )
+
+// fakeBrowser is a minimal kooky.BrowserInfo for testing the store-key derivation.
+type fakeBrowser struct{ path string }
+
+func (f fakeBrowser) Browser() string        { return "chrome" }
+func (f fakeBrowser) Profile() string        { return "default" }
+func (f fakeBrowser) IsDefaultProfile() bool { return true }
+func (f fakeBrowser) FilePath() string       { return f.path }
+
+func TestMapKookyCookies(t *testing.T) {
+	in := []*kooky.Cookie{
+		{Cookie: http.Cookie{Domain: "github.com", Name: "user_session", Value: "v1"}, Container: "c1"},
+		{Cookie: http.Cookie{Domain: "github.com", Name: "logged_in", Value: "yes"}, Container: "c2", Browser: fakeBrowser{path: "/p"}},
+	}
+	got := mapKookyCookies(in)
+	if len(got) != 2 {
+		t.Fatalf("got %d cookies, want 2", len(got))
+	}
+	// Browser nil → store is just the container.
+	if got[0].store != "c1" || got[0].name != "user_session" || got[0].value != "v1" || got[0].domain != "github.com" {
+		t.Errorf("cookie 0 = %+v", got[0])
+	}
+	// Browser set → store is FilePath()+"\x00"+Container.
+	if got[1].store != "/p\x00c2" || got[1].name != "logged_in" {
+		t.Errorf("cookie 1 = %+v", got[1])
+	}
+}
 
 func TestNewSessionCookie(t *testing.T) {
 	c := NewSessionCookie("  raw value  ")
@@ -126,6 +156,33 @@ func recordingValidator(dead ...string) (func(*http.Cookie) error, *[]string) {
 		}
 		return nil
 	}, &calls
+}
+
+func TestChooseSession(t *testing.T) {
+	t.Run("empty raw with read error wraps it", func(t *testing.T) {
+		_, err := chooseSession(nil, fmt.Errorf("keyring locked"), nil)
+		if err == nil || !strings.Contains(err.Error(), "reading browser cookies") {
+			t.Fatalf("expected wrapped read error, got %v", err)
+		}
+	})
+
+	t.Run("empty raw without read error is the not-logged-in message", func(t *testing.T) {
+		_, err := chooseSession(nil, nil, nil)
+		if err == nil || !strings.Contains(err.Error(), "no github.com user_session cookie found") {
+			t.Fatalf("expected not-logged-in message, got %v", err)
+		}
+	})
+
+	t.Run("usable candidates ignore a read error and delegate to selectSession", func(t *testing.T) {
+		raw := []rawCookie{us("A", "tok"), li("A", "yes")}
+		got, err := chooseSession(raw, fmt.Errorf("partial read error"), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Value != "tok" {
+			t.Errorf("got %q, want tok", got.Value)
+		}
+	})
 }
 
 func cand(store, value string, loggedIn bool) sessionCandidate {

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -15,14 +15,23 @@ type Info struct {
 	ID    int
 }
 
+// runner runs an external command and returns its stdout. Injected so the
+// git/gh subprocess boundary is stubbable in tests.
+type runner func(name string, args ...string) ([]byte, error)
+
+// execRun is the production runner; it shells out via os/exec.
+func execRun(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
 var (
 	sshRemoteRe   = regexp.MustCompile(`git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$`)
 	httpsRemoteRe = regexp.MustCompile(`https://github\.com/([^/]+)/([^/]+?)(?:\.git)?$`)
 )
 
-// FromRemote infers the GitHub owner/repo from the git remote in the current directory.
-func FromRemote() (owner, name string, err error) {
-	out, err := exec.Command("git", "remote", "get-url", "origin").Output()
+// fromRemote infers the GitHub owner/repo from the git remote in the current directory.
+func fromRemote(run runner) (owner, name string, err error) {
+	out, err := run("git", "remote", "get-url", "origin")
 	if err != nil {
 		return "", "", fmt.Errorf("not a git repository or no 'origin' remote configured")
 	}
@@ -38,9 +47,9 @@ func FromRemote() (owner, name string, err error) {
 	return "", "", fmt.Errorf("could not parse GitHub owner/repo from remote URL: %s", remote)
 }
 
-// LookupID resolves the numeric repository ID via the gh CLI.
-func LookupID(owner, name string) (int, error) {
-	out, err := exec.Command("gh", "api", fmt.Sprintf("repos/%s/%s", owner, name), "--jq", ".id").Output()
+// lookupID resolves the numeric repository ID via the gh CLI.
+func lookupID(run runner, owner, name string) (int, error) {
+	out, err := run("gh", "api", fmt.Sprintf("repos/%s/%s", owner, name), "--jq", ".id")
 	if err != nil {
 		return 0, fmt.Errorf("failed to look up repo ID for %s/%s (is gh CLI installed and authenticated?): %w", owner, name, err)
 	}
@@ -51,20 +60,25 @@ func LookupID(owner, name string) (int, error) {
 	return id, nil
 }
 
-// Resolve returns full repo info. If owner/name are empty, it infers from the git remote.
-func Resolve(owner, name string) (*Info, error) {
+// resolve returns full repo info, inferring owner/name from the git remote when empty.
+func resolve(run runner, owner, name string) (*Info, error) {
 	if owner == "" || name == "" {
 		var err error
-		owner, name, err = FromRemote()
+		owner, name, err = fromRemote(run)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	id, err := LookupID(owner, name)
+	id, err := lookupID(run, owner, name)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Info{Owner: owner, Name: name, ID: id}, nil
+}
+
+// Resolve returns full repo info. If owner/name are empty, it infers from the git remote.
+func Resolve(owner, name string) (*Info, error) {
+	return resolve(execRun, owner, name)
 }

--- a/internal/repo/repo_test.go
+++ b/internal/repo/repo_test.go
@@ -1,0 +1,142 @@
+package repo
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// fakeRunner answers `git` and `gh` invocations from canned output/errors and
+// records the args each was called with.
+type fakeRunner struct {
+	gitOut, ghOut string
+	gitErr, ghErr error
+	gotGit, gotGh [][]string
+}
+
+func (f *fakeRunner) run(name string, args ...string) ([]byte, error) {
+	switch name {
+	case "git":
+		f.gotGit = append(f.gotGit, args)
+		return []byte(f.gitOut), f.gitErr
+	case "gh":
+		f.gotGh = append(f.gotGh, args)
+		return []byte(f.ghOut), f.ghErr
+	default:
+		return nil, fmt.Errorf("unexpected command %q", name)
+	}
+}
+
+func TestFromRemote(t *testing.T) {
+	cases := []struct {
+		name        string
+		gitOut      string
+		gitErr      error
+		wantOwner   string
+		wantName    string
+		errContains string
+	}{
+		{name: "ssh with .git", gitOut: "git@github.com:octocat/hello.git\n", wantOwner: "octocat", wantName: "hello"},
+		{name: "ssh without .git", gitOut: "git@github.com:octocat/hello", wantOwner: "octocat", wantName: "hello"},
+		{name: "https with .git", gitOut: "https://github.com/octocat/hello.git\n", wantOwner: "octocat", wantName: "hello"},
+		{name: "https without .git", gitOut: "https://github.com/octocat/hello", wantOwner: "octocat", wantName: "hello"},
+		{name: "git command error", gitErr: fmt.Errorf("exit 128"), errContains: "not a git repository"},
+		{name: "non-github remote", gitOut: "https://gitlab.com/x/y.git", errContains: "could not parse GitHub owner/repo from remote URL: https://gitlab.com/x/y.git"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &fakeRunner{gitOut: tc.gitOut, gitErr: tc.gitErr}
+			owner, name, err := fromRemote(f.run)
+			if tc.errContains != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.errContains)
+				}
+				if got := err.Error(); !strings.Contains(got, tc.errContains) {
+					t.Fatalf("error = %q, want substring %q", got, tc.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if owner != tc.wantOwner || name != tc.wantName {
+				t.Fatalf("got %s/%s, want %s/%s", owner, name, tc.wantOwner, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestLookupID(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		f := &fakeRunner{ghOut: "12345\n"}
+		id, err := lookupID(f.run, "octocat", "hello")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if id != 12345 {
+			t.Errorf("id = %d, want 12345", id)
+		}
+		want := []string{"api", "repos/octocat/hello", "--jq", ".id"}
+		if len(f.gotGh) != 1 || !reflect.DeepEqual(f.gotGh[0], want) {
+			t.Errorf("gh args = %v, want %v", f.gotGh, want)
+		}
+	})
+
+	t.Run("gh command error", func(t *testing.T) {
+		f := &fakeRunner{ghErr: fmt.Errorf("not authenticated")}
+		_, err := lookupID(f.run, "octocat", "hello")
+		if err == nil || !strings.Contains(err.Error(), "failed to look up repo ID for octocat/hello") {
+			t.Fatalf("expected lookup error, got %v", err)
+		}
+	})
+
+	t.Run("non-numeric output", func(t *testing.T) {
+		f := &fakeRunner{ghOut: "not-a-number\n"}
+		_, err := lookupID(f.run, "octocat", "hello")
+		if err == nil || !strings.Contains(err.Error(), "unexpected repo ID format: not-a-number") {
+			t.Fatalf("expected format error, got %v", err)
+		}
+	})
+}
+
+func TestResolve(t *testing.T) {
+	t.Run("explicit owner/name skips git", func(t *testing.T) {
+		f := &fakeRunner{ghOut: "42"}
+		info, err := resolve(f.run, "octocat", "hello")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if *info != (Info{Owner: "octocat", Name: "hello", ID: 42}) {
+			t.Errorf("info = %+v", info)
+		}
+		if len(f.gotGit) != 0 {
+			t.Errorf("git should not be called when owner/name are explicit, got %v", f.gotGit)
+		}
+	})
+
+	t.Run("empty owner infers from remote", func(t *testing.T) {
+		f := &fakeRunner{gitOut: "git@github.com:octocat/hello.git\n", ghOut: "7"}
+		info, err := resolve(f.run, "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if *info != (Info{Owner: "octocat", Name: "hello", ID: 7}) {
+			t.Errorf("info = %+v", info)
+		}
+	})
+
+	t.Run("fromRemote error propagates", func(t *testing.T) {
+		f := &fakeRunner{gitErr: fmt.Errorf("no remote")}
+		if _, err := resolve(f.run, "", ""); err == nil {
+			t.Fatal("expected error from fromRemote, got nil")
+		}
+	})
+
+	t.Run("lookupID error propagates", func(t *testing.T) {
+		f := &fakeRunner{ghErr: fmt.Errorf("boom")}
+		if _, err := resolve(f.run, "octocat", "hello"); err == nil {
+			t.Fatal("expected error from lookupID, got nil")
+		}
+	})
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -13,6 +13,10 @@ import (
 
 var userLoginRe = regexp.MustCompile(`<meta name="user-login" content="([^"]+)"`)
 
+// profileURL is the endpoint CheckValidity probes. A var (not a const) so tests can
+// point CheckValidity at an httptest server and exercise it end-to-end.
+var profileURL = "https://github.com/settings/profile"
+
 // CheckValidity verifies a GitHub session cookie is valid.
 // It returns the authenticated username on success, or an error if the token
 // is invalid, expired, or if the network request fails.
@@ -34,7 +38,7 @@ func CheckValidity(sessionCookie *http.Cookie) (string, error) {
 			return http.ErrUseLastResponse
 		},
 	}
-	return checkValidity(client, "https://github.com/settings/profile", sessionCookie)
+	return checkValidity(client, profileURL, sessionCookie)
 }
 
 // checkValidity does the real work of validating a session cookie against a

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -53,6 +54,29 @@ func TestCheckValidity_ValidNoUsername(t *testing.T) {
 	}
 	if username != "" {
 		t.Errorf("expected empty username, got %q", username)
+	}
+}
+
+// TestCheckValidity_EndToEnd exercises the exported CheckValidity (its client
+// construction + delegation) against a plain-HTTP server. Plain HTTP is correct:
+// CheckValidity builds its own http.Client with the default transport, which reaches
+// 127.0.0.1 without a self-signed cert. Kept serial — profileURL is process-global.
+func TestCheckValidity_EndToEnd(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, `<meta name="user-login" content="octo">`) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	old := profileURL
+	profileURL = srv.URL
+	defer func() { profileURL = old }()
+
+	got, err := CheckValidity(&http.Cookie{Name: "user_session", Value: "t"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "octo" {
+		t.Errorf("username = %q, want octo", got)
 	}
 }
 

--- a/internal/upload/token.go
+++ b/internal/upload/token.go
@@ -37,10 +37,10 @@ func isSAMLProtected(body []byte, owner string) bool {
 	return orgSSOLink || ssoTitle
 }
 
-// GetUploadToken fetches the repo page and extracts the uploadToken
+// getUploadToken fetches the repo page and extracts the uploadToken
 // from the JS payload. Requires authenticated cookies in the client.
-func GetUploadToken(client *http.Client, owner, repo string) (string, error) {
-	url := fmt.Sprintf("https://github.com/%s/%s", owner, repo)
+func (c *Client) getUploadToken(owner, repo string) (string, error) {
+	url := fmt.Sprintf("%s/%s/%s", c.baseURL, owner, repo)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -48,7 +48,7 @@ func GetUploadToken(client *http.Client, owner, repo string) (string, error) {
 	}
 	req.Header.Set("User-Agent", httputil.UserAgent)
 
-	resp, err := client.Do(req)
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("fetching repo page: %w", err)
 	}

--- a/internal/upload/token_test.go
+++ b/internal/upload/token_test.go
@@ -2,7 +2,6 @@ package upload
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -123,16 +122,8 @@ func TestGetUploadToken(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				if tc.status != 0 {
-					w.WriteHeader(tc.status)
-				}
-				_, _ = w.Write([]byte(tc.body))
-			}))
-			defer srv.Close()
-
-			c := &Client{http: srv.Client(), baseURL: srv.URL}
-			tok, err := c.getUploadToken(tc.owner, "hello")
+			srv := newJSONServer(t, tc.status, tc.body)
+			tok, err := testClient(srv).getUploadToken(tc.owner, "hello")
 
 			if tc.wantToken != "" {
 				if err != nil {

--- a/internal/upload/token_test.go
+++ b/internal/upload/token_test.go
@@ -1,8 +1,8 @@
 package upload
 
 import (
-	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -88,7 +88,8 @@ func TestGetUploadToken(t *testing.T) {
 	cases := []struct {
 		name        string
 		owner       string
-		body        string
+		status      int      // response status (0 => 200)
+		body        string   // response body
 		wantToken   string   // non-empty => expect success
 		errContains []string // substrings the error must include
 		errExcludes []string // substrings the error must NOT include
@@ -112,11 +113,26 @@ func TestGetUploadToken(t *testing.T) {
 			body:        `<html>just a page, no token</html>`,
 			errContains: []string{"do you have write access to octocat/hello"},
 		},
+		{
+			name:        "non-200 status reports the repo page status",
+			owner:       "octocat",
+			status:      http.StatusNotFound,
+			body:        "not found",
+			errContains: []string{"repo page returned 404"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := &http.Client{Transport: stubTransport(http.StatusOK, tc.body)}
-			tok, err := GetUploadToken(client, tc.owner, "hello")
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.status != 0 {
+					w.WriteHeader(tc.status)
+				}
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			c := &Client{http: srv.Client(), baseURL: srv.URL}
+			tok, err := c.getUploadToken(tc.owner, "hello")
 
 			if tc.wantToken != "" {
 				if err != nil {
@@ -143,22 +159,4 @@ func TestGetUploadToken(t *testing.T) {
 			}
 		})
 	}
-}
-
-// stubTransport answers every request with the given status and body, so
-// GetUploadToken's hardcoded github.com URL is served locally without a network
-// call.
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
-
-func stubTransport(status int, body string) http.RoundTripper {
-	return roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: status,
-			Body:       io.NopCloser(strings.NewReader(body)),
-			Header:     make(http.Header),
-			Request:    r,
-		}, nil
-	})
 }

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -38,19 +38,30 @@ type policyResponse struct {
 	AssetUploadAuthenticityToken string            `json:"asset_upload_authenticity_token"`
 }
 
-// NewClient creates an http.Client with the GitHub session cookies set.
+// Client carries the HTTP client (with GitHub session cookies) and the base URL
+// for GitHub requests. baseURL has no trailing slash; the production value is
+// "https://github.com". Tests point it at an httptest server.
+type Client struct {
+	http    *http.Client
+	baseURL string
+}
+
+// NewClient creates a Client with the GitHub session cookies set.
 // GitHub requires both user_session and __Host-user_session_same_site
 // for CSRF validation on the upload endpoint.
-func NewClient(sessionCookie *http.Cookie) *http.Client {
-	return &http.Client{
-		Jar:     cookies.NewGitHubCookieJar(sessionCookie),
-		Timeout: 30 * time.Second,
+func NewClient(sessionCookie *http.Cookie) *Client {
+	return &Client{
+		http: &http.Client{
+			Jar:     cookies.NewGitHubCookieJar(sessionCookie),
+			Timeout: 30 * time.Second,
+		},
+		baseURL: "https://github.com",
 	}
 }
 
 // Upload uploads an image file to GitHub and returns the asset URL.
 // owner/repo identifies the target repository, repoID is its numeric ID.
-func Upload(client *http.Client, owner, repo string, repoID int, imagePath string) (*Result, error) {
+func (c *Client) Upload(owner, repo string, repoID int, imagePath string) (*Result, error) {
 	info, err := os.Stat(imagePath)
 	if err != nil {
 		return nil, fmt.Errorf("image file: %w", err)
@@ -59,13 +70,13 @@ func Upload(client *http.Client, owner, repo string, repoID int, imagePath strin
 	fileName := filepath.Base(imagePath)
 
 	// Step 0: Get uploadToken from repo page
-	uploadToken, err := GetUploadToken(client, owner, repo)
+	uploadToken, err := c.getUploadToken(owner, repo)
 	if err != nil {
 		return nil, fmt.Errorf("step 0 (get upload token): %w", err)
 	}
 
 	// Step 1: Request upload policy
-	policy, err := requestPolicy(client, owner, repo, uploadToken, repoID, fileName, info.Size(), contentType)
+	policy, err := c.requestPolicy(owner, repo, uploadToken, repoID, fileName, info.Size(), contentType)
 	if err != nil {
 		return nil, fmt.Errorf("step 1 (request policy): %w", err)
 	}
@@ -77,7 +88,7 @@ func Upload(client *http.Client, owner, repo string, repoID int, imagePath strin
 	}
 
 	// Step 3: Finalize the upload
-	result, err := finalizeUpload(client, owner, repo, policy)
+	result, err := c.finalizeUpload(owner, repo, policy)
 	if err != nil {
 		return nil, fmt.Errorf("step 3 (finalize): %w", err)
 	}
@@ -86,7 +97,7 @@ func Upload(client *http.Client, owner, repo string, repoID int, imagePath strin
 }
 
 // requestPolicy calls POST /upload/policies/assets to get the S3 presigned form.
-func requestPolicy(client *http.Client, owner, repo, uploadToken string, repoID int, fileName string, fileSize int64, contentType string) (*policyResponse, error) {
+func (c *Client) requestPolicy(owner, repo, uploadToken string, repoID int, fileName string, fileSize int64, contentType string) (*policyResponse, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
@@ -103,18 +114,18 @@ func requestPolicy(client *http.Client, owner, repo, uploadToken string, repoID 
 	}
 	writer.Close()
 
-	req, err := http.NewRequest("POST", "https://github.com/upload/policies/assets", body)
+	req, err := http.NewRequest("POST", c.baseURL+"/upload/policies/assets", body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	req.Header.Set("Origin", "https://github.com")
-	req.Header.Set("Referer", fmt.Sprintf("https://github.com/%s/%s", owner, repo))
+	req.Header.Set("Origin", c.baseURL)
+	req.Header.Set("Referer", fmt.Sprintf("%s/%s/%s", c.baseURL, owner, repo))
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
 	req.Header.Set("User-Agent", httputil.UserAgent)
 
-	resp, err := client.Do(req)
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +158,7 @@ func requestPolicy(client *http.Client, owner, repo, uploadToken string, repoID 
 }
 
 // finalizeUpload calls PUT /upload/assets/{id} to mark the asset as ready.
-func finalizeUpload(client *http.Client, owner, repo string, policy *policyResponse) (*Result, error) {
+func (c *Client) finalizeUpload(owner, repo string, policy *policyResponse) (*Result, error) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 	if err := writer.WriteField("authenticity_token", policy.AssetUploadAuthenticityToken); err != nil {
@@ -155,18 +166,18 @@ func finalizeUpload(client *http.Client, owner, repo string, policy *policyRespo
 	}
 	writer.Close()
 
-	req, err := http.NewRequest("PUT", fmt.Sprintf("https://github.com/upload/assets/%d", policy.Asset.ID), body)
+	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/upload/assets/%d", c.baseURL, policy.Asset.ID), body)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	req.Header.Set("Origin", "https://github.com")
-	req.Header.Set("Referer", fmt.Sprintf("https://github.com/%s/%s", owner, repo))
+	req.Header.Set("Origin", c.baseURL)
+	req.Header.Set("Referer", fmt.Sprintf("%s/%s/%s", c.baseURL, owner, repo))
 	req.Header.Set("X-Requested-With", "XMLHttpRequest")
 	req.Header.Set("User-Agent", httputil.UserAgent)
 
-	resp, err := client.Do(req)
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -17,6 +17,27 @@ func testClient(srv *httptest.Server) *Client {
 	return &Client{http: srv.Client(), baseURL: srv.URL}
 }
 
+// newServer starts an httptest server with the given handler and registers
+// cleanup, so callers don't repeat defer srv.Close().
+func newServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newJSONServer starts a server that answers every request with the given
+// status (0 => 200) and body.
+func newJSONServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	return newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if status != 0 {
+			w.WriteHeader(status)
+		}
+		_, _ = w.Write([]byte(body))
+	})
+}
+
 // validPolicy is a policy response body with all required fields populated.
 // uploadURL is filled in per-test to point at the test server's S3 route.
 func validPolicy(uploadURL string) string {
@@ -44,7 +65,7 @@ func TestNewClient(t *testing.T) {
 func TestRequestPolicy(t *testing.T) {
 	t.Run("success parses the policy and sends the form fields", func(t *testing.T) {
 		var gotFields map[string]string
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
 			_ = r.ParseMultipartForm(1 << 20)
 			gotFields = map[string]string{}
 			for k, v := range r.MultipartForm.Value {
@@ -52,8 +73,7 @@ func TestRequestPolicy(t *testing.T) {
 			}
 			w.WriteHeader(http.StatusCreated)
 			_, _ = w.Write([]byte(validPolicy("https://s3.example/upload")))
-		}))
-		defer srv.Close()
+		})
 
 		policy, err := testClient(srv).requestPolicy("octo", "hello", "UTOKEN", 42, "pic.png", 1234, "image/png")
 		if err != nil {
@@ -74,11 +94,7 @@ func TestRequestPolicy(t *testing.T) {
 	})
 
 	t.Run("non-201 status is an error with the body", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusForbidden)
-			_, _ = w.Write([]byte("denied"))
-		}))
-		defer srv.Close()
+		srv := newJSONServer(t, http.StatusForbidden, "denied")
 		_, err := testClient(srv).requestPolicy("octo", "hello", "t", 1, "f", 1, "image/png")
 		if err == nil || !strings.Contains(err.Error(), "expected 201, got 403") || !strings.Contains(err.Error(), "denied") {
 			t.Fatalf("expected 403 error with body, got %v", err)
@@ -97,11 +113,7 @@ func TestRequestPolicy(t *testing.T) {
 		}
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(http.StatusCreated)
-					_, _ = w.Write([]byte(tc.body))
-				}))
-				defer srv.Close()
+				srv := newJSONServer(t, http.StatusCreated, tc.body)
 				_, err := testClient(srv).requestPolicy("octo", "hello", "t", 1, "f", 1, "image/png")
 				if err == nil || !strings.Contains(err.Error(), tc.want) {
 					t.Fatalf("want error %q, got %v", tc.want, err)
@@ -116,7 +128,7 @@ func TestFinalizeUpload(t *testing.T) {
 	policy.Asset.ID = 99
 
 	t.Run("success builds the full Result", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
 			if r.Method != http.MethodPut {
 				t.Errorf("method = %s, want PUT", r.Method)
 			}
@@ -124,8 +136,7 @@ func TestFinalizeUpload(t *testing.T) {
 				t.Errorf("path = %s, want .../upload/assets/99", r.URL.Path)
 			}
 			_, _ = w.Write([]byte(`{"href":"https://gh/assets/x","name":"pic.png"}`))
-		}))
-		defer srv.Close()
+		})
 
 		res, err := testClient(srv).finalizeUpload("octo", "hello", policy)
 		if err != nil {
@@ -137,11 +148,7 @@ func TestFinalizeUpload(t *testing.T) {
 	})
 
 	t.Run("non-200 is an error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-			_, _ = w.Write([]byte("boom"))
-		}))
-		defer srv.Close()
+		srv := newJSONServer(t, http.StatusInternalServerError, "boom")
 		_, err := testClient(srv).finalizeUpload("octo", "hello", policy)
 		if err == nil || !strings.Contains(err.Error(), "expected 200, got 500") {
 			t.Fatalf("expected 500 error, got %v", err)
@@ -149,10 +156,7 @@ func TestFinalizeUpload(t *testing.T) {
 	})
 
 	t.Run("malformed json is an error", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`{not json`))
-		}))
-		defer srv.Close()
+		srv := newJSONServer(t, 0, `{not json`)
 		_, err := testClient(srv).finalizeUpload("octo", "hello", policy)
 		if err == nil || !strings.Contains(err.Error(), "decoding finalize response") {
 			t.Fatalf("expected decode error, got %v", err)
@@ -175,7 +179,7 @@ func TestUploadToS3(t *testing.T) {
 
 	t.Run("success on 2xx; file is the last field", func(t *testing.T) {
 		var lastField string
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv := newServer(t, func(w http.ResponseWriter, r *http.Request) {
 			mr, err := r.MultipartReader()
 			if err != nil {
 				t.Fatalf("not multipart: %v", err)
@@ -188,8 +192,7 @@ func TestUploadToS3(t *testing.T) {
 				lastField = part.FormName()
 			}
 			w.WriteHeader(http.StatusNoContent)
-		}))
-		defer srv.Close()
+		})
 
 		if err := uploadToS3(policy(srv.URL), writeFile(t), "pic.png", "image/png"); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -200,11 +203,7 @@ func TestUploadToS3(t *testing.T) {
 	})
 
 	t.Run("non-2xx is an error with the body", func(t *testing.T) {
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusForbidden)
-			_, _ = w.Write([]byte("policy violation"))
-		}))
-		defer srv.Close()
+		srv := newJSONServer(t, http.StatusForbidden, "policy violation")
 		err := uploadToS3(policy(srv.URL), writeFile(t), "pic.png", "image/png")
 		if err == nil || !strings.Contains(err.Error(), "S3 returned 403") || !strings.Contains(err.Error(), "policy violation") {
 			t.Fatalf("expected 403 error with body, got %v", err)
@@ -229,54 +228,23 @@ func TestUploadToS3(t *testing.T) {
 	})
 }
 
-func TestUpload_FullFlow(t *testing.T) {
+// TestUpload_Flow drives the full four-step upload flow through one server that
+// routes every step. With failStep == "" it asserts the happy-path Result;
+// otherwise it makes exactly that step fail and checks Upload's matching
+// step-wrapping error branch. Plain HTTP (not TLS): the S3 leg uses uploadToS3's
+// own bare client with the default transport.
+func TestUpload_Flow(t *testing.T) {
 	img := filepath.Join(t.TempDir(), "shot.png")
 	if err := os.WriteFile(img, []byte("pngbytes"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
-	// One server routes all four steps. Plain HTTP (not TLS): the S3 leg uses
-	// uploadToS3's own bare client with the default transport.
-	mux := http.NewServeMux()
-	var srv *httptest.Server
-	mux.HandleFunc("/octo/hello", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`x={"uploadToken":"TKN"}`))
-	})
-	mux.HandleFunc("/upload/policies/assets", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(validPolicy(srv.URL + "/s3")))
-	})
-	mux.HandleFunc("/s3", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNoContent)
-	})
-	mux.HandleFunc("/upload/assets/99", func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write([]byte(`{"href":"https://gh/assets/x","name":"shot.png"}`))
-	})
-	srv = httptest.NewServer(mux)
-	defer srv.Close()
-
-	res, err := testClient(srv).Upload("octo", "hello", 42, img)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if res.Markdown != "![shot.png](https://gh/assets/x)" {
-		t.Errorf("Markdown = %q", res.Markdown)
-	}
-}
-
-// TestUpload_StepErrors drives the full flow but makes one step fail, covering
-// each of Upload's step-wrapping error branches.
-func TestUpload_StepErrors(t *testing.T) {
-	img := filepath.Join(t.TempDir(), "shot.png")
-	if err := os.WriteFile(img, []byte("png"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
 	cases := []struct {
 		name      string
-		failStep  string // which route returns a failure
+		failStep  string // which route returns a failure ("" => happy path)
 		wantInErr string
 	}{
+		{"success", "", ""},
 		{"step 0 token", "token", "step 0 (get upload token)"},
 		{"step 1 policy", "policy", "step 1 (request policy)"},
 		{"step 2 s3", "s3", "step 2 (S3 upload)"},
@@ -313,12 +281,21 @@ func TestUpload_StepErrors(t *testing.T) {
 					w.WriteHeader(http.StatusInternalServerError)
 					return
 				}
-				_, _ = w.Write([]byte(`{"href":"h","name":"n"}`))
+				_, _ = w.Write([]byte(`{"href":"https://gh/assets/x","name":"shot.png"}`))
 			})
 			srv = httptest.NewServer(mux)
 			defer srv.Close()
 
-			_, err := testClient(srv).Upload("octo", "hello", 42, img)
+			res, err := testClient(srv).Upload("octo", "hello", 42, img)
+			if tc.failStep == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if res.Markdown != "![shot.png](https://gh/assets/x)" {
+					t.Errorf("Markdown = %q", res.Markdown)
+				}
+				return
+			}
 			if err == nil || !strings.Contains(err.Error(), tc.wantInErr) {
 				t.Fatalf("want error %q, got %v", tc.wantInErr, err)
 			}

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -1,0 +1,381 @@
+package upload
+
+import (
+	"encoding/json"
+	"fmt"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// testClient returns a Client wired to a test server.
+func testClient(srv *httptest.Server) *Client {
+	return &Client{http: srv.Client(), baseURL: srv.URL}
+}
+
+// validPolicy is a policy response body with all required fields populated.
+// uploadURL is filled in per-test to point at the test server's S3 route.
+func validPolicy(uploadURL string) string {
+	return fmt.Sprintf(`{
+		"upload_url": %q,
+		"asset": {"id": 99, "name": "pic.png"},
+		"form": {"key": "k", "policy": "p"},
+		"asset_upload_authenticity_token": "AUTH"
+	}`, uploadURL)
+}
+
+func TestNewClient(t *testing.T) {
+	c := NewClient(&http.Cookie{Name: "user_session", Value: "tok"})
+	if c == nil || c.http == nil {
+		t.Fatal("expected non-nil Client with non-nil http client")
+	}
+	if c.baseURL != "https://github.com" {
+		t.Errorf("baseURL = %q, want https://github.com", c.baseURL)
+	}
+	if c.http.Jar == nil {
+		t.Error("expected the http client to carry the GitHub cookie jar")
+	}
+}
+
+func TestRequestPolicy(t *testing.T) {
+	t.Run("success parses the policy and sends the form fields", func(t *testing.T) {
+		var gotFields map[string]string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_ = r.ParseMultipartForm(1 << 20)
+			gotFields = map[string]string{}
+			for k, v := range r.MultipartForm.Value {
+				gotFields[k] = v[0]
+			}
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(validPolicy("https://s3.example/upload")))
+		}))
+		defer srv.Close()
+
+		policy, err := testClient(srv).requestPolicy("octo", "hello", "UTOKEN", 42, "pic.png", 1234, "image/png")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if policy.UploadURL != "https://s3.example/upload" || policy.Asset.ID != 99 || policy.AssetUploadAuthenticityToken != "AUTH" {
+			t.Errorf("unexpected policy: %+v", policy)
+		}
+		want := map[string]string{
+			"name": "pic.png", "size": "1234", "content_type": "image/png",
+			"authenticity_token": "UTOKEN", "repository_id": "42",
+		}
+		for k, v := range want {
+			if gotFields[k] != v {
+				t.Errorf("form field %q = %q, want %q", k, gotFields[k], v)
+			}
+		}
+	})
+
+	t.Run("non-201 status is an error with the body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("denied"))
+		}))
+		defer srv.Close()
+		_, err := testClient(srv).requestPolicy("octo", "hello", "t", 1, "f", 1, "image/png")
+		if err == nil || !strings.Contains(err.Error(), "expected 201, got 403") || !strings.Contains(err.Error(), "denied") {
+			t.Fatalf("expected 403 error with body, got %v", err)
+		}
+	})
+
+	t.Run("missing required fields each error", func(t *testing.T) {
+		cases := []struct {
+			name, body, want string
+		}{
+			{"no upload_url", `{"asset":{"id":1},"form":{"k":"v"},"asset_upload_authenticity_token":"a"}`, "missing upload_url"},
+			{"no auth token", `{"upload_url":"u","asset":{"id":1},"form":{"k":"v"}}`, "missing asset_upload_authenticity_token"},
+			{"no form", `{"upload_url":"u","asset":{"id":1},"asset_upload_authenticity_token":"a"}`, "missing form fields"},
+			{"no asset id", `{"upload_url":"u","form":{"k":"v"},"asset_upload_authenticity_token":"a"}`, "missing asset ID"},
+			{"bad json", `{not json`, "decoding policy response"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusCreated)
+					_, _ = w.Write([]byte(tc.body))
+				}))
+				defer srv.Close()
+				_, err := testClient(srv).requestPolicy("octo", "hello", "t", 1, "f", 1, "image/png")
+				if err == nil || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("want error %q, got %v", tc.want, err)
+				}
+			})
+		}
+	})
+}
+
+func TestFinalizeUpload(t *testing.T) {
+	policy := &policyResponse{AssetUploadAuthenticityToken: "AUTH"}
+	policy.Asset.ID = 99
+
+	t.Run("success builds the full Result", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodPut {
+				t.Errorf("method = %s, want PUT", r.Method)
+			}
+			if !strings.HasSuffix(r.URL.Path, "/upload/assets/99") {
+				t.Errorf("path = %s, want .../upload/assets/99", r.URL.Path)
+			}
+			_, _ = w.Write([]byte(`{"href":"https://gh/assets/x","name":"pic.png"}`))
+		}))
+		defer srv.Close()
+
+		res, err := testClient(srv).finalizeUpload("octo", "hello", policy)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if res.URL != "https://gh/assets/x" || res.Name != "pic.png" || res.Markdown != "![pic.png](https://gh/assets/x)" {
+			t.Errorf("unexpected Result: %+v", res)
+		}
+	})
+
+	t.Run("non-200 is an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("boom"))
+		}))
+		defer srv.Close()
+		_, err := testClient(srv).finalizeUpload("octo", "hello", policy)
+		if err == nil || !strings.Contains(err.Error(), "expected 200, got 500") {
+			t.Fatalf("expected 500 error, got %v", err)
+		}
+	})
+
+	t.Run("malformed json is an error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(`{not json`))
+		}))
+		defer srv.Close()
+		_, err := testClient(srv).finalizeUpload("octo", "hello", policy)
+		if err == nil || !strings.Contains(err.Error(), "decoding finalize response") {
+			t.Fatalf("expected decode error, got %v", err)
+		}
+	})
+}
+
+func TestUploadToS3(t *testing.T) {
+	writeFile := func(t *testing.T) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "pic.png")
+		if err := os.WriteFile(p, []byte("imagedata"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	policy := func(url string) *policyResponse {
+		return &policyResponse{UploadURL: url, Form: map[string]string{"key": "k", "extra": "z"}}
+	}
+
+	t.Run("success on 2xx; file is the last field", func(t *testing.T) {
+		var lastField string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mr, err := r.MultipartReader()
+			if err != nil {
+				t.Fatalf("not multipart: %v", err)
+			}
+			for {
+				part, err := mr.NextPart()
+				if err != nil {
+					break
+				}
+				lastField = part.FormName()
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer srv.Close()
+
+		if err := uploadToS3(policy(srv.URL), writeFile(t), "pic.png", "image/png"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if lastField != "file" {
+			t.Errorf("last multipart field = %q, want file", lastField)
+		}
+	})
+
+	t.Run("non-2xx is an error with the body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("policy violation"))
+		}))
+		defer srv.Close()
+		err := uploadToS3(policy(srv.URL), writeFile(t), "pic.png", "image/png")
+		if err == nil || !strings.Contains(err.Error(), "S3 returned 403") || !strings.Contains(err.Error(), "policy violation") {
+			t.Fatalf("expected 403 error with body, got %v", err)
+		}
+	})
+
+	t.Run("missing file is an error before any request", func(t *testing.T) {
+		err := uploadToS3(policy("http://127.0.0.1:0"), filepath.Join(t.TempDir(), "nope.png"), "nope.png", "image/png")
+		if err == nil || !strings.Contains(err.Error(), "opening file") {
+			t.Fatalf("expected opening-file error, got %v", err)
+		}
+	})
+
+	t.Run("unreachable S3 endpoint is a request error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		url := srv.URL
+		srv.Close()
+		err := uploadToS3(policy(url), writeFile(t), "pic.png", "image/png")
+		if err == nil || !strings.Contains(err.Error(), "S3 upload request") {
+			t.Fatalf("expected S3 request error, got %v", err)
+		}
+	})
+}
+
+func TestUpload_FullFlow(t *testing.T) {
+	img := filepath.Join(t.TempDir(), "shot.png")
+	if err := os.WriteFile(img, []byte("pngbytes"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// One server routes all four steps. Plain HTTP (not TLS): the S3 leg uses
+	// uploadToS3's own bare client with the default transport.
+	mux := http.NewServeMux()
+	var srv *httptest.Server
+	mux.HandleFunc("/octo/hello", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`x={"uploadToken":"TKN"}`))
+	})
+	mux.HandleFunc("/upload/policies/assets", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(validPolicy(srv.URL + "/s3")))
+	})
+	mux.HandleFunc("/s3", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/upload/assets/99", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"href":"https://gh/assets/x","name":"shot.png"}`))
+	})
+	srv = httptest.NewServer(mux)
+	defer srv.Close()
+
+	res, err := testClient(srv).Upload("octo", "hello", 42, img)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Markdown != "![shot.png](https://gh/assets/x)" {
+		t.Errorf("Markdown = %q", res.Markdown)
+	}
+}
+
+// TestUpload_StepErrors drives the full flow but makes one step fail, covering
+// each of Upload's step-wrapping error branches.
+func TestUpload_StepErrors(t *testing.T) {
+	img := filepath.Join(t.TempDir(), "shot.png")
+	if err := os.WriteFile(img, []byte("png"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name      string
+		failStep  string // which route returns a failure
+		wantInErr string
+	}{
+		{"step 0 token", "token", "step 0 (get upload token)"},
+		{"step 1 policy", "policy", "step 1 (request policy)"},
+		{"step 2 s3", "s3", "step 2 (S3 upload)"},
+		{"step 3 finalize", "finalize", "step 3 (finalize)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			var srv *httptest.Server
+			mux.HandleFunc("/octo/hello", func(w http.ResponseWriter, r *http.Request) {
+				if tc.failStep == "token" {
+					_, _ = w.Write([]byte(`no token here`))
+					return
+				}
+				_, _ = w.Write([]byte(`x={"uploadToken":"TKN"}`))
+			})
+			mux.HandleFunc("/upload/policies/assets", func(w http.ResponseWriter, r *http.Request) {
+				if tc.failStep == "policy" {
+					w.WriteHeader(http.StatusForbidden)
+					return
+				}
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(validPolicy(srv.URL + "/s3")))
+			})
+			mux.HandleFunc("/s3", func(w http.ResponseWriter, r *http.Request) {
+				if tc.failStep == "s3" {
+					w.WriteHeader(http.StatusForbidden)
+					return
+				}
+				w.WriteHeader(http.StatusNoContent)
+			})
+			mux.HandleFunc("/upload/assets/99", func(w http.ResponseWriter, r *http.Request) {
+				if tc.failStep == "finalize" {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				_, _ = w.Write([]byte(`{"href":"h","name":"n"}`))
+			})
+			srv = httptest.NewServer(mux)
+			defer srv.Close()
+
+			_, err := testClient(srv).Upload("octo", "hello", 42, img)
+			if err == nil || !strings.Contains(err.Error(), tc.wantInErr) {
+				t.Fatalf("want error %q, got %v", tc.wantInErr, err)
+			}
+		})
+	}
+}
+
+func TestGetUploadToken_NetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := srv.URL
+	srv.Close() // now unreachable
+	c := &Client{http: &http.Client{}, baseURL: url}
+	_, err := c.getUploadToken("octo", "hello")
+	if err == nil || !strings.Contains(err.Error(), "fetching repo page") {
+		t.Fatalf("expected fetch error, got %v", err)
+	}
+}
+
+func TestUpload_StatErrorBeforeRequests(t *testing.T) {
+	c := NewClient(&http.Cookie{Name: "user_session", Value: "t"})
+	_, err := c.Upload("octo", "hello", 1, filepath.Join(t.TempDir(), "missing.png"))
+	if err == nil || !strings.Contains(err.Error(), "image file:") {
+		t.Fatalf("expected image-file error, got %v", err)
+	}
+}
+
+func TestDetectContentType(t *testing.T) {
+	// Make the test hermetic: minimal CI images may lack .png in the mime registry.
+	_ = mime.AddExtensionType(".png", "image/png")
+	if ct := detectContentType("a.png"); !strings.HasPrefix(ct, "image/png") {
+		t.Errorf("detectContentType(.png) = %q, want image/png prefix", ct)
+	}
+	if ct := detectContentType("a.zzz"); ct != "application/octet-stream" {
+		t.Errorf("detectContentType(.zzz) = %q, want application/octet-stream", ct)
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("short", 200); got != "short" {
+		t.Errorf("short string changed: %q", got)
+	}
+	if got := truncate("abcdef", 3); got != "abc..." {
+		t.Errorf("truncate to 3 = %q, want abc...", got)
+	}
+	// Multibyte: 3 runes of a 5-rune string, not split mid-rune.
+	if got := truncate("héllo", 3); got != "hél..." {
+		t.Errorf("multibyte truncate = %q, want hél...", got)
+	}
+}
+
+// jsonRoundTrip guards the policyResponse tags against accidental drift.
+func TestPolicyResponseJSONTags(t *testing.T) {
+	var p policyResponse
+	if err := json.Unmarshal([]byte(validPolicy("u")), &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if p.Asset.Name != "pic.png" {
+		t.Errorf("asset.name = %q", p.Asset.Name)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ type uploadFunc func(info *repo.Info, imagePath string) (string, error)
 // tests inject stubs so the orchestration spine runs without network/subprocess/exit.
 type deps struct {
 	resolveRepo   func(owner, name string) (*repo.Info, error)
-	resolveCookie func(tokenFlag string) (*http.Cookie, string, error)
+	resolveCookie func(tokenFlag string) (*http.Cookie, error)
 	// newUploader builds an uploader from a session cookie. It is called once per
 	// run so the underlying HTTP client (and its cookie jar) is shared across all
 	// images, matching the single-client behavior of the original implementation.
@@ -45,8 +45,11 @@ type deps struct {
 
 func productionDeps() deps {
 	return deps{
-		resolveRepo:   repo.Resolve,
-		resolveCookie: resolveSessionCookie,
+		resolveRepo: repo.Resolve,
+		resolveCookie: func(tokenFlag string) (*http.Cookie, error) {
+			cookie, _, err := resolveSessionCookie(tokenFlag)
+			return cookie, err
+		},
 		newUploader: func(cookie *http.Cookie) uploadFunc {
 			client := upload.NewClient(cookie)
 			return func(info *repo.Info, imagePath string) (string, error) {
@@ -243,7 +246,7 @@ func run(args []string, stdout, stderr io.Writer, d deps) int {
 	}
 
 	// Get session cookie (flag > env var > browser)
-	cookie, _, err := d.resolveCookie(tokenFlag)
+	cookie, err := d.resolveCookie(tokenFlag)
 	if err != nil {
 		fmt.Fprintf(stderr, "Error: %v\n", err)
 		return 1

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -23,6 +24,50 @@ const usage = `Usage:
 var version = "dev"
 
 func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, productionDeps()))
+}
+
+// uploadFunc uploads one image and returns its markdown reference.
+type uploadFunc func(info *repo.Info, imagePath string) (string, error)
+
+// deps are the I/O boundaries run() depends on; productionDeps wires the real ones,
+// tests inject stubs so the orchestration spine runs without network/subprocess/exit.
+type deps struct {
+	resolveRepo   func(owner, name string) (*repo.Info, error)
+	resolveCookie func(tokenFlag string) (*http.Cookie, string, error)
+	// newUploader builds an uploader from a session cookie. It is called once per
+	// run so the underlying HTTP client (and its cookie jar) is shared across all
+	// images, matching the single-client behavior of the original implementation.
+	newUploader  func(cookie *http.Cookie) uploadFunc
+	extractToken func() (string, error)
+	checkToken   func(tokenFlag string) (username, source string, err error)
+}
+
+func productionDeps() deps {
+	return deps{
+		resolveRepo:   repo.Resolve,
+		resolveCookie: resolveSessionCookie,
+		newUploader: func(cookie *http.Cookie) uploadFunc {
+			client := upload.NewClient(cookie)
+			return func(info *repo.Info, imagePath string) (string, error) {
+				res, err := client.Upload(info.Owner, info.Name, info.ID, imagePath)
+				if err != nil {
+					return "", err
+				}
+				return res.Markdown, nil
+			}
+		},
+		// extract-token stays offline: pass nil so selection skips network validation.
+		extractToken: func() (string, error) {
+			return extractToken(func() (*http.Cookie, error) { return cookies.GetGitHubSession(nil) })
+		},
+		checkToken: func(tokenFlag string) (string, string, error) {
+			return checkToken(tokenFlag, resolveSessionCookie, session.CheckValidity)
+		},
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer, d deps) int {
 	var repoFlag string
 	var repoSet bool
 	var tokenFlag string
@@ -31,7 +76,6 @@ func main() {
 	var firstPosAfterDoubleDash bool
 
 	// Manual arg parsing so flags can appear anywhere (before or after positional args).
-	args := os.Args[1:]
 	flagsDone := false
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
@@ -50,82 +94,82 @@ func main() {
 			flagsDone = true
 		case arg == "--repo":
 			if repoSet {
-				fmt.Fprintf(os.Stderr, "Error: --repo specified more than once\n")
-				os.Exit(1)
+				fmt.Fprintf(stderr, "Error: --repo specified more than once\n")
+				return 1
 			}
 			if i+1 >= len(args) {
-				fmt.Fprintf(os.Stderr, "Error: --repo requires a value (owner/repo)\n%s\n", usage)
-				os.Exit(1)
+				fmt.Fprintf(stderr, "Error: --repo requires a value (owner/repo)\n%s\n", usage)
+				return 1
 			}
 			i++
 			repoFlag = args[i]
 			repoSet = true
 		case strings.HasPrefix(arg, "--repo="):
 			if repoSet {
-				fmt.Fprintf(os.Stderr, "Error: --repo specified more than once\n")
-				os.Exit(1)
+				fmt.Fprintf(stderr, "Error: --repo specified more than once\n")
+				return 1
 			}
 			repoFlag = strings.SplitN(arg, "=", 2)[1]
 			repoSet = true
 		case arg == "--token":
 			if tokenSet {
-				fmt.Fprintf(os.Stderr, "Error: --token specified more than once\n")
-				os.Exit(1)
+				fmt.Fprintf(stderr, "Error: --token specified more than once\n")
+				return 1
 			}
 			if i+1 >= len(args) {
-				fmt.Fprintf(os.Stderr, "Error: --token requires a value\n%s\n", usage)
-				os.Exit(1)
+				fmt.Fprintf(stderr, "Error: --token requires a value\n%s\n", usage)
+				return 1
 			}
 			i++
 			tokenFlag = strings.TrimSpace(args[i])
 			if tokenFlag == "" {
-				fmt.Fprintf(os.Stderr, "Error: --token value cannot be empty\n%s\n", usage)
-				os.Exit(1)
+				fmt.Fprintf(stderr, "Error: --token value cannot be empty\n%s\n", usage)
+				return 1
 			}
 			tokenSet = true
 		case strings.HasPrefix(arg, "--token="):
 			if tokenSet {
-				fmt.Fprintf(os.Stderr, "Error: --token specified more than once\n")
-				os.Exit(1)
+				fmt.Fprintf(stderr, "Error: --token specified more than once\n")
+				return 1
 			}
 			tokenFlag = strings.TrimSpace(strings.SplitN(arg, "=", 2)[1])
 			if tokenFlag == "" {
-				fmt.Fprintf(os.Stderr, "Error: --token value cannot be empty\n%s\n", usage)
-				os.Exit(1)
+				fmt.Fprintf(stderr, "Error: --token value cannot be empty\n%s\n", usage)
+				return 1
 			}
 			tokenSet = true
 		case arg == "--version":
-			fmt.Printf("gh-image %s\n", version)
-			os.Exit(0)
+			fmt.Fprintf(stdout, "gh-image %s\n", version)
+			return 0
 		case arg == "--help" || arg == "-h":
-			fmt.Printf("%s\n\n", usage)
-			fmt.Println("Upload images to GitHub and print markdown references.")
-			fmt.Println()
-			fmt.Println("The --repo flag is optional. If omitted, the repository is")
-			fmt.Println("inferred from the git remote in the current directory.")
-			fmt.Println()
-			fmt.Println("Flags:")
-			fmt.Println("  --repo owner/repo   GitHub repository (optional)")
-			fmt.Println("  --token <value>     GitHub session token (default: extracted from browser)")
-			fmt.Println("                      Can also be set via GH_SESSION_TOKEN environment variable")
-			fmt.Println("                      WARNING: --token values are visible in process listings.")
-			fmt.Println("                      Prefer GH_SESSION_TOKEN on shared machines.")
-			fmt.Println("  --version           Print version and exit")
-			fmt.Println()
-			fmt.Println("Subcommands:")
-			fmt.Println("  extract-token       Extract session token from browser and print to stdout")
-			fmt.Println("  check-token         Verify a session token is valid and print username to stdout")
-			fmt.Println()
-			fmt.Println("Use -- to separate flags from filenames starting with a dash:")
-			fmt.Println("  gh image -- -screenshot.png")
-			os.Exit(0)
+			fmt.Fprintf(stdout, "%s\n\n", usage)
+			fmt.Fprintln(stdout, "Upload images to GitHub and print markdown references.")
+			fmt.Fprintln(stdout)
+			fmt.Fprintln(stdout, "The --repo flag is optional. If omitted, the repository is")
+			fmt.Fprintln(stdout, "inferred from the git remote in the current directory.")
+			fmt.Fprintln(stdout)
+			fmt.Fprintln(stdout, "Flags:")
+			fmt.Fprintln(stdout, "  --repo owner/repo   GitHub repository (optional)")
+			fmt.Fprintln(stdout, "  --token <value>     GitHub session token (default: extracted from browser)")
+			fmt.Fprintln(stdout, "                      Can also be set via GH_SESSION_TOKEN environment variable")
+			fmt.Fprintln(stdout, "                      WARNING: --token values are visible in process listings.")
+			fmt.Fprintln(stdout, "                      Prefer GH_SESSION_TOKEN on shared machines.")
+			fmt.Fprintln(stdout, "  --version           Print version and exit")
+			fmt.Fprintln(stdout)
+			fmt.Fprintln(stdout, "Subcommands:")
+			fmt.Fprintln(stdout, "  extract-token       Extract session token from browser and print to stdout")
+			fmt.Fprintln(stdout, "  check-token         Verify a session token is valid and print username to stdout")
+			fmt.Fprintln(stdout)
+			fmt.Fprintln(stdout, "Use -- to separate flags from filenames starting with a dash:")
+			fmt.Fprintln(stdout, "  gh image -- -screenshot.png")
+			return 0
 		case strings.HasPrefix(arg, "-") && arg != "-":
-			fmt.Fprintf(os.Stderr, "Error: unknown flag %s\n", arg)
+			fmt.Fprintf(stderr, "Error: unknown flag %s\n", arg)
 			if strings.HasPrefix(arg, "-") && !strings.HasPrefix(arg, "--") {
-				fmt.Fprintf(os.Stderr, "If this is a filename, use: gh image -- %s\n", arg)
+				fmt.Fprintf(stderr, "If this is a filename, use: gh image -- %s\n", arg)
 			}
-			fmt.Fprintf(os.Stderr, "Run 'gh image --help' for usage.\n")
-			os.Exit(1)
+			fmt.Fprintf(stderr, "Run 'gh image --help' for usage.\n")
+			return 1
 		default:
 			imagePaths = append(imagePaths, arg)
 		}
@@ -134,32 +178,46 @@ func main() {
 	// Dispatch subcommands before any other validation.
 	subcommand, dispatchErr := classifySubcommand(imagePaths, firstPosAfterDoubleDash, tokenFlag, repoSet)
 	if dispatchErr != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", dispatchErr)
+		fmt.Fprintf(stderr, "Error: %v\n", dispatchErr)
 		var ue *usageError
 		if errors.As(dispatchErr, &ue) {
-			fmt.Fprintf(os.Stderr, "%s\nRun 'gh image --help' for usage.\n", usage)
+			fmt.Fprintf(stderr, "%s\nRun 'gh image --help' for usage.\n", usage)
 		}
-		os.Exit(1)
+		return 1
 	}
 	switch subcommand {
 	case "extract-token":
-		handleExtractToken()
-		return
+		value, err := d.extractToken()
+		if err != nil {
+			fmt.Fprintf(stderr, "Error: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stderr, "Extracted session token from browser cookies")
+		fmt.Fprintln(stdout, value)
+		return 0
 	case "check-token":
-		handleCheckToken(tokenFlag)
-		return
+		username, source, err := d.checkToken(tokenFlag)
+		if err != nil {
+			fmt.Fprintf(stderr, "Error: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stderr, "Token is valid (source: %s)\n", source)
+		if username != "" {
+			fmt.Fprintln(stdout, username)
+		}
+		return 0
 	}
 
 	if len(imagePaths) == 0 {
-		fmt.Fprintf(os.Stderr, "%s\nRun 'gh image --help' for usage.\n", usage)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "%s\nRun 'gh image --help' for usage.\n", usage)
+		return 1
 	}
 
 	// Validate image paths early
 	for _, p := range imagePaths {
 		if p == "" {
-			fmt.Fprintf(os.Stderr, "Error: empty image path\n")
-			os.Exit(1)
+			fmt.Fprintf(stderr, "Error: empty image path\n")
+			return 1
 		}
 	}
 
@@ -167,46 +225,48 @@ func main() {
 	var owner, name string
 	if repoSet {
 		if repoFlag == "" {
-			fmt.Fprintf(os.Stderr, "Error: --repo value cannot be empty\n")
-			os.Exit(1)
+			fmt.Fprintf(stderr, "Error: --repo value cannot be empty\n")
+			return 1
 		}
 		parts := strings.SplitN(repoFlag, "/", 2)
 		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			fmt.Fprintf(os.Stderr, "Error: --repo must be in owner/repo format, got: %s\n", repoFlag)
-			os.Exit(1)
+			fmt.Fprintf(stderr, "Error: --repo must be in owner/repo format, got: %s\n", repoFlag)
+			return 1
 		}
 		owner, name = parts[0], parts[1]
 	}
 
-	repoInfo, err := repo.Resolve(owner, name)
+	repoInfo, err := d.resolveRepo(owner, name)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error resolving repository: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error resolving repository: %v\n", err)
+		return 1
 	}
 
 	// Get session cookie (flag > env var > browser)
-	cookie, _, err := resolveSessionCookie(tokenFlag)
+	cookie, _, err := d.resolveCookie(tokenFlag)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
+		fmt.Fprintf(stderr, "Error: %v\n", err)
+		return 1
 	}
 
-	client := upload.NewClient(cookie)
+	// Build the uploader once so its HTTP client/cookie jar is shared across images.
+	uploadImage := d.newUploader(cookie)
 
 	// Upload each image, continuing on error
 	hasError := false
 	for _, imagePath := range imagePaths {
-		result, err := upload.Upload(client, repoInfo.Owner, repoInfo.Name, repoInfo.ID, imagePath)
+		markdown, err := uploadImage(repoInfo, imagePath)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error uploading %s: %v\n", imagePath, err)
+			fmt.Fprintf(stderr, "Error uploading %s: %v\n", imagePath, err)
 			hasError = true
 			continue
 		}
-		fmt.Println(result.Markdown)
+		fmt.Fprintln(stdout, markdown)
 	}
 	if hasError {
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
 // usageError wraps an error to signal that usage text should be shown alongside the message.
@@ -305,19 +365,6 @@ func extractToken(getBrowserCookie func() (*http.Cookie, error)) (string, error)
 	return cookie.Value, nil
 }
 
-// handleExtractToken extracts the session cookie from the browser and prints
-// the raw token value to stdout. Source info is written to stderr.
-func handleExtractToken() {
-	// extract-token stays offline: pass nil so selection skips network validation.
-	value, err := extractToken(func() (*http.Cookie, error) { return cookies.GetGitHubSession(nil) })
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Fprintln(os.Stderr, "Extracted session token from browser cookies")
-	fmt.Println(value)
-}
-
 // checkToken resolves and validates a session token, returning the authenticated username and source.
 func checkToken(tokenFlag string, resolver func(string) (*http.Cookie, string, error), validator func(*http.Cookie) (string, error)) (string, string, error) {
 	cookie, source, err := resolver(tokenFlag)
@@ -329,18 +376,4 @@ func checkToken(tokenFlag string, resolver func(string) (*http.Cookie, string, e
 		return "", "", err
 	}
 	return username, source, nil
-}
-
-// handleCheckToken verifies the session cookie and prints the username to stdout.
-// Token source is resolved via resolveSessionCookie (flag > env var > browser).
-func handleCheckToken(tokenFlag string) {
-	username, source, err := checkToken(tokenFlag, resolveSessionCookie, session.CheckValidity)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
-	fmt.Fprintf(os.Stderr, "Token is valid (source: %s)\n", source)
-	if username != "" {
-		fmt.Println(username)
-	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -19,8 +19,8 @@ func okDeps() deps {
 		resolveRepo: func(owner, name string) (*repo.Info, error) {
 			return &repo.Info{Owner: "octo", Name: "hello", ID: 1}, nil
 		},
-		resolveCookie: func(tokenFlag string) (*http.Cookie, string, error) {
-			return &http.Cookie{Name: "user_session", Value: "tok"}, "stub", nil
+		resolveCookie: func(tokenFlag string) (*http.Cookie, error) {
+			return &http.Cookie{Name: "user_session", Value: "tok"}, nil
 		},
 		newUploader: func(cookie *http.Cookie) uploadFunc {
 			return func(info *repo.Info, imagePath string) (string, error) {
@@ -420,7 +420,7 @@ func TestRun_Upload(t *testing.T) {
 	})
 	t.Run("resolveCookie error exits 1", func(t *testing.T) {
 		d := okDeps()
-		d.resolveCookie = func(string) (*http.Cookie, string, error) { return nil, "", fmt.Errorf("no token") }
+		d.resolveCookie = func(string) (*http.Cookie, error) { return nil, fmt.Errorf("no token") }
 		code, _, errOut := runWith(t, []string{"a.png"}, d)
 		if code != 1 || !strings.Contains(errOut, "Error:") {
 			t.Fatalf("code=%d stderr=%q", code, errOut)

--- a/main_test.go
+++ b/main_test.go
@@ -1,14 +1,44 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"testing"
 
+	"github.com/drogers0/gh-image/internal/repo"
 	"github.com/drogers0/gh-image/internal/upload"
 )
+
+// okDeps returns deps whose boundaries all succeed; tests override individual
+// fields to exercise specific paths.
+func okDeps() deps {
+	return deps{
+		resolveRepo: func(owner, name string) (*repo.Info, error) {
+			return &repo.Info{Owner: "octo", Name: "hello", ID: 1}, nil
+		},
+		resolveCookie: func(tokenFlag string) (*http.Cookie, string, error) {
+			return &http.Cookie{Name: "user_session", Value: "tok"}, "stub", nil
+		},
+		newUploader: func(cookie *http.Cookie) uploadFunc {
+			return func(info *repo.Info, imagePath string) (string, error) {
+				return "![" + imagePath + "](url)", nil
+			}
+		},
+		extractToken: func() (string, error) { return "extracted-token", nil },
+		checkToken:   func(tokenFlag string) (string, string, error) { return "octouser", "stub", nil },
+	}
+}
+
+// runWith executes run() with buffered streams and returns the exit code + output.
+func runWith(t *testing.T, args []string, d deps) (code int, stdout, stderr string) {
+	t.Helper()
+	var so, se bytes.Buffer
+	code = run(args, &so, &se, d)
+	return code, so.String(), se.String()
+}
 
 // TestCookieFromValue_BasicAttributes verifies the cookie has the expected fields.
 func TestCookieFromValue_BasicAttributes(t *testing.T) {
@@ -237,6 +267,232 @@ func TestResolveSessionCookie_WhitespaceFlag(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "empty") {
 		t.Errorf("expected error containing 'empty', got: %v", err)
+	}
+}
+
+func TestRun_VersionAndHelp(t *testing.T) {
+	t.Run("version prints to stdout and exits 0", func(t *testing.T) {
+		code, out, _ := runWith(t, []string{"--version"}, okDeps())
+		if code != 0 {
+			t.Fatalf("code = %d, want 0", code)
+		}
+		if !strings.Contains(out, "gh-image dev") {
+			t.Errorf("stdout = %q, want version string", out)
+		}
+	})
+	for _, flag := range []string{"--help", "-h"} {
+		t.Run(flag+" prints usage to stdout and exits 0", func(t *testing.T) {
+			code, out, _ := runWith(t, []string{flag}, okDeps())
+			if code != 0 {
+				t.Fatalf("code = %d, want 0", code)
+			}
+			if !strings.Contains(out, "Usage:") || !strings.Contains(out, "extract-token") {
+				t.Errorf("stdout missing usage content: %q", out)
+			}
+		})
+	}
+}
+
+func TestRun_FlagErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string // substring expected on stderr
+	}{
+		{"unknown long flag", []string{"--bogus"}, "unknown flag --bogus"},
+		{"unknown short flag hints --", []string{"-x"}, "use: gh image -- -x"},
+		{"repo twice", []string{"--repo", "a/b", "--repo", "c/d"}, "specified more than once"},
+		{"repo missing value", []string{"--repo"}, "requires a value"},
+		{"repo empty via =", []string{"--repo=", "img.png"}, "--repo value cannot be empty"},
+		{"repo bad format", []string{"--repo", "noslash", "img.png"}, "must be in owner/repo format"},
+		{"token twice", []string{"--token", "a", "--token", "b"}, "specified more than once"},
+		{"token missing value", []string{"--token"}, "requires a value"},
+		{"token empty value", []string{"--token", "   "}, "cannot be empty"},
+		{"no args shows usage", nil, "Usage:"},
+		{"empty image path", []string{""}, "empty image path"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, _, errOut := runWith(t, tc.args, okDeps())
+			if code != 1 {
+				t.Fatalf("code = %d, want 1", code)
+			}
+			if !strings.Contains(errOut, tc.want) {
+				t.Errorf("stderr = %q, want substring %q", errOut, tc.want)
+			}
+		})
+	}
+}
+
+func TestRun_Subcommands(t *testing.T) {
+	t.Run("extract-token success", func(t *testing.T) {
+		code, out, errOut := runWith(t, []string{"extract-token"}, okDeps())
+		if code != 0 || strings.TrimSpace(out) != "extracted-token" {
+			t.Fatalf("code=%d out=%q", code, out)
+		}
+		if !strings.Contains(errOut, "Extracted session token") {
+			t.Errorf("stderr missing status: %q", errOut)
+		}
+	})
+	t.Run("extract-token error", func(t *testing.T) {
+		d := okDeps()
+		d.extractToken = func() (string, error) { return "", fmt.Errorf("no browser") }
+		code, _, errOut := runWith(t, []string{"extract-token"}, d)
+		if code != 1 || !strings.Contains(errOut, "no browser") {
+			t.Fatalf("code=%d stderr=%q", code, errOut)
+		}
+	})
+	t.Run("check-token success prints username", func(t *testing.T) {
+		code, out, errOut := runWith(t, []string{"check-token"}, okDeps())
+		if code != 0 || strings.TrimSpace(out) != "octouser" {
+			t.Fatalf("code=%d out=%q", code, out)
+		}
+		if !strings.Contains(errOut, "Token is valid (source: stub)") {
+			t.Errorf("stderr = %q", errOut)
+		}
+	})
+	t.Run("check-token empty username prints nothing to stdout", func(t *testing.T) {
+		d := okDeps()
+		d.checkToken = func(string) (string, string, error) { return "", "stub", nil }
+		code, out, _ := runWith(t, []string{"check-token"}, d)
+		if code != 0 || strings.TrimSpace(out) != "" {
+			t.Fatalf("code=%d out=%q", code, out)
+		}
+	})
+	t.Run("check-token error", func(t *testing.T) {
+		d := okDeps()
+		d.checkToken = func(string) (string, string, error) { return "", "", fmt.Errorf("expired") }
+		code, _, errOut := runWith(t, []string{"check-token"}, d)
+		if code != 1 || !strings.Contains(errOut, "expired") {
+			t.Fatalf("code=%d stderr=%q", code, errOut)
+		}
+	})
+	t.Run("extract-token with --token is a conflict error", func(t *testing.T) {
+		code, _, errOut := runWith(t, []string{"extract-token", "--token", "x"}, okDeps())
+		if code != 1 || !strings.Contains(errOut, "--token cannot be combined") {
+			t.Fatalf("code=%d stderr=%q", code, errOut)
+		}
+	})
+}
+
+func TestRun_Upload(t *testing.T) {
+	t.Run("single image prints markdown, exits 0", func(t *testing.T) {
+		code, out, _ := runWith(t, []string{"a.png"}, okDeps())
+		if code != 0 || strings.TrimSpace(out) != "![a.png](url)" {
+			t.Fatalf("code=%d out=%q", code, out)
+		}
+	})
+	t.Run("multiple images print one line each", func(t *testing.T) {
+		code, out, _ := runWith(t, []string{"a.png", "b.png"}, okDeps())
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		if code != 0 || len(lines) != 2 {
+			t.Fatalf("code=%d out=%q", code, out)
+		}
+	})
+	t.Run("partial failure exits 1 but prints successes", func(t *testing.T) {
+		d := okDeps()
+		d.newUploader = func(c *http.Cookie) uploadFunc {
+			return func(info *repo.Info, p string) (string, error) {
+				if p == "bad.png" {
+					return "", fmt.Errorf("upload failed")
+				}
+				return "![" + p + "](url)", nil
+			}
+		}
+		code, out, errOut := runWith(t, []string{"good.png", "bad.png"}, d)
+		if code != 1 {
+			t.Fatalf("code = %d, want 1", code)
+		}
+		if !strings.Contains(out, "![good.png](url)") {
+			t.Errorf("stdout missing success line: %q", out)
+		}
+		if !strings.Contains(errOut, "Error uploading bad.png") {
+			t.Errorf("stderr missing failure: %q", errOut)
+		}
+	})
+	t.Run("resolveRepo error exits 1", func(t *testing.T) {
+		d := okDeps()
+		d.resolveRepo = func(string, string) (*repo.Info, error) { return nil, fmt.Errorf("no remote") }
+		code, _, errOut := runWith(t, []string{"a.png"}, d)
+		if code != 1 || !strings.Contains(errOut, "Error resolving repository") {
+			t.Fatalf("code=%d stderr=%q", code, errOut)
+		}
+	})
+	t.Run("resolveCookie error exits 1", func(t *testing.T) {
+		d := okDeps()
+		d.resolveCookie = func(string) (*http.Cookie, string, error) { return nil, "", fmt.Errorf("no token") }
+		code, _, errOut := runWith(t, []string{"a.png"}, d)
+		if code != 1 || !strings.Contains(errOut, "Error:") {
+			t.Fatalf("code=%d stderr=%q", code, errOut)
+		}
+	})
+	t.Run("explicit --repo is parsed and passed to resolveRepo", func(t *testing.T) {
+		var gotOwner, gotName string
+		d := okDeps()
+		d.resolveRepo = func(owner, name string) (*repo.Info, error) {
+			gotOwner, gotName = owner, name
+			return &repo.Info{Owner: owner, Name: name, ID: 9}, nil
+		}
+		runWith(t, []string{"--repo", "acme/widgets", "a.png"}, d)
+		if gotOwner != "acme" || gotName != "widgets" {
+			t.Errorf("resolveRepo got %q/%q, want acme/widgets", gotOwner, gotName)
+		}
+	})
+	t.Run("-- terminator treats dash-file as a path and infers repo", func(t *testing.T) {
+		var gotOwner, gotName string
+		d := okDeps()
+		d.resolveRepo = func(owner, name string) (*repo.Info, error) {
+			gotOwner, gotName = owner, name
+			return &repo.Info{Owner: "octo", Name: "hello", ID: 1}, nil
+		}
+		code, out, _ := runWith(t, []string{"--", "-shot.png"}, d)
+		if code != 0 {
+			t.Fatalf("code = %d, want 0", code)
+		}
+		if gotOwner != "" || gotName != "" {
+			t.Errorf("expected inference path (empty owner/name), got %q/%q", gotOwner, gotName)
+		}
+		if !strings.Contains(out, "![-shot.png](url)") {
+			t.Errorf("stdout = %q", out)
+		}
+	})
+}
+
+func TestRun_UsageErrorDispatchShowsUsage(t *testing.T) {
+	// A usageError from classifySubcommand prints the usage block alongside the error.
+	code, _, errOut := runWith(t, []string{"extract-token", "extra"}, okDeps())
+	if code != 1 {
+		t.Fatalf("code = %d, want 1", code)
+	}
+	if !strings.Contains(errOut, "does not take positional arguments") || !strings.Contains(errOut, "Usage:") {
+		t.Errorf("stderr = %q, want error + usage", errOut)
+	}
+}
+
+func TestResolveSessionCookie_EnvPath(t *testing.T) {
+	// Exercises the production resolveSessionCookie via the env var, so it never
+	// touches the browser: the env value wins before the browser getter is built.
+	t.Setenv("GH_SESSION_TOKEN", "env-token-value")
+	cookie, source, err := resolveSessionCookie("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cookie.Value != "env-token-value" || source != "GH_SESSION_TOKEN" {
+		t.Errorf("got value=%q source=%q", cookie.Value, source)
+	}
+}
+
+func TestResolveSessionCookie_NilGetter(t *testing.T) {
+	_, _, err := resolveSessionCookieWithGetter("", "", nil)
+	if err == nil || !strings.Contains(err.Error(), "browser session getter is unavailable") {
+		t.Fatalf("expected nil-getter error, got %v", err)
+	}
+}
+
+func TestProductionDeps_WiringComplete(t *testing.T) {
+	d := productionDeps()
+	if d.resolveRepo == nil || d.resolveCookie == nil || d.newUploader == nil || d.extractToken == nil || d.checkToken == nil {
+		t.Fatal("productionDeps left a boundary unwired")
 	}
 }
 


### PR DESCRIPTION
## Why

Coverage was low not because of too few tests, but because the code doing the real work had no test seam: the network, the `git`/`gh` subprocess, and `os.Exit` were hardwired, and the program spine sat in one large `main()`. Those parts were structurally unreachable from tests.

Before → after (pooled statement coverage):

| Package | Before | After |
|---|---|---|
| `.` (main) | 24.1% | ~89% |
| `internal/upload` | 14.3% | ~91% |
| `internal/repo` | 0.0% | ~93% |
| `internal/session` | 81.5% | ~89% |
| `internal/cookies` | 75.0% | ~92% |
| **pooled total** | — | **90.1%** |

## What

Strictly behavior-preserving seams (no user-facing change — same flags, output, exit codes, URLs, and headers):

- **main**: extract `run(args, stdout, stderr, deps) int` from `main()`; inject the I/O boundaries via a `deps` struct so the full CLI spine is tested without network/subprocess/exit. The upload client is built **once per run** (shared cookie jar), matching prior behavior. Dead `handleExtractToken`/`handleCheckToken` removed.
- **upload**: introduce `*Client{http, baseURL}` with methods so `requestPolicy`/`finalizeUpload`/`getUploadToken` run against an `httptest` server instead of a hardcoded `github.com` URL.
- **repo**: inject a command `runner` so remote-URL and ID parsing are testable without a real git repo or authenticated `gh`.
- **cookies**: split pure `chooseSession` + `mapKookyCookies` out of the `kooky` browser read (now the only untested unit).
- **session**: add a `profileURL` var seam so `CheckValidity` is exercised end-to-end.
- **docs**: `architecture.md` updated for the changed signatures.

## Accepted coverage gaps

`internal/httputil` (a single const), `cookies.readRawCookies` (live browser read via kooky), a few unreachable defensive branches, and thin production wiring (`main`, `productionDeps`, `resolveSessionCookie`).

## Validation

`gofmt -l .` clean · `go vet ./...` clean · `go test -race ./...` pass · pooled coverage 90.1%.