### PR TITLE
Migrate to golangci-lint, replace retired Go Report Card badge

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+version: "2"
+
+linters:
+  default: standard
+  settings:
+    errcheck:
+      # Writes to stdout/stderr are not actionable: if the write itself fails
+      # there is no working channel left to report the failure, and the CLI is
+      # about to exit anyway. Errors from every other call are still checked.
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/drogers0/gh-image/stargazers"><img src="https://img.shields.io/github/stars/drogers0/gh-image?style=flat&color=yellow" alt="GitHub stars"></a>
   <a href="https://github.com/drogers0/gh-image/releases"><img src="https://img.shields.io/github/downloads/drogers0/gh-image/total?color=green" alt="Total downloads"></a>
   <a href="LICENSE"><img src="https://img.shields.io/github/license/drogers0/gh-image?color=lightgrey" alt="License: MIT"></a>
-  <a href="https://goreportcard.com/report/github.com/drogers0/gh-image"><img src="https://goreportcard.com/badge/github.com/drogers0/gh-image" alt="Go Report Card"></a>
+  <a href="https://github.com/drogers0/gh-image/actions/workflows/lint.yml"><img src="https://github.com/drogers0/gh-image/actions/workflows/lint.yml/badge.svg" alt="Lint"></a>
   <a href="https://skills.sh/drogers0/gh-image"><img src="https://skills.sh/b/drogers0/gh-image" alt="skills.sh"></a>
 </p>
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -58,7 +58,7 @@ func checkValidity(client *http.Client, targetURL string, sessionCookie *http.Co
 	if err != nil {
 		return "", fmt.Errorf("failed to validate token: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:

--- a/internal/upload/s3.go
+++ b/internal/upload/s3.go
@@ -66,7 +66,7 @@ func uploadToS3(policy *policyResponse, filePath, fileName, contentType string) 
 	if err != nil {
 		return fmt.Errorf("opening file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if _, err := io.Copy(part, f); err != nil {
 		return fmt.Errorf("writing file data: %w", err)
@@ -89,7 +89,7 @@ func uploadToS3(policy *policyResponse, filePath, fileName, contentType string) 
 	if err != nil {
 		return fmt.Errorf("S3 upload request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/internal/upload/token.go
+++ b/internal/upload/token.go
@@ -52,7 +52,7 @@ func (c *Client) getUploadToken(owner, repo string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("fetching repo page: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("repo page returned %d — do you have access to %s/%s?", resp.StatusCode, owner, repo)

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -118,7 +118,9 @@ func (c *Client) requestPolicy(owner, repo, uploadToken string, repoID int, file
 			return nil, fmt.Errorf("writing form field %s: %w", f.k, err)
 		}
 	}
-	writer.Close()
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("closing multipart writer: %w", err)
+	}
 
 	req, err := http.NewRequest("POST", c.baseURL+"/upload/policies/assets", body)
 	if err != nil {
@@ -135,7 +137,7 @@ func (c *Client) requestPolicy(owner, repo, uploadToken string, repoID int, file
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated {
 		respBody, _ := io.ReadAll(resp.Body)
@@ -187,7 +189,9 @@ func (c *Client) finalizeUpload(owner, repo string, policy *policyResponse) (*Re
 	if err := writer.WriteField("authenticity_token", policy.AssetUploadAuthenticityToken); err != nil {
 		return nil, fmt.Errorf("writing form field authenticity_token: %w", err)
 	}
-	writer.Close()
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("closing multipart writer: %w", err)
+	}
 
 	req, err := http.NewRequest("PUT", c.baseURL+policy.AssetUploadURL, body)
 	if err != nil {
@@ -204,7 +208,7 @@ func (c *Client) finalizeUpload(owner, repo string, policy *policyResponse) (*Re
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		respBody, _ := io.ReadAll(resp.Body)

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -348,13 +348,13 @@ func TestUpload_Flow_NonImage(t *testing.T) {
 	})
 	mux.HandleFunc("/upload/policies/assets", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-		_, _ = w.Write([]byte(fmt.Sprintf(`{
+		_, _ = fmt.Fprintf(w, `{
 			"upload_url": %q,
 			"asset": {"id": 99, "name": "report.pdf", "content_type": "application/pdf"},
 			"form": {"key": "k", "policy": "p"},
 			"asset_upload_url": "/upload/repository-files/99",
 			"asset_upload_authenticity_token": "AUTH"
-		}`, srv.URL+"/s3")))
+		}`, srv.URL+"/s3")
 	})
 	mux.HandleFunc("/s3", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
Closes #25.

Go Report Card has been [sunset](https://goreportcard.com/); its badge endpoint now literally renders `go report | retired`, making the README look broken. This migrates the repo to **golangci-lint** and replaces the dead pill with a Lint workflow status badge.

## What changed

**CI / config (new)**
- `.golangci.yml` — v2 schema, `standard` linters. errcheck excludes the `fmt.Fprint*` family (unactionable stdout/stderr writes).
- `.github/workflows/lint.yml` — runs golangci-lint (pinned `v2.12.2`) on push to `main` and all PRs.

**Lint fixes** — `golangci-lint run` went from 57 findings (56 errcheck + 1 staticcheck) to **0**:
- `upload.go` — the two multipart `writer.Close()` calls now check their error, matching the existing pattern in `s3.go`. This is the only behavior change: on a Close error they now return early instead of sending a malformed body (the buffer-backed Close never errors in practice).
- Deferred response-body/file `Close()` calls wrapped to discard the error explicitly.
- `upload_test.go` — `Write([]byte(fmt.Sprintf(...)))` → `fmt.Fprintf` (staticcheck QF1012).
- ~48 `fmt.Fprint*` writes to stdout/stderr in `main.go` are excluded via config rather than edited — a failed write there isn't actionable and editing each would be pure noise.

**README** — retired Go Report Card badge → `Lint` workflow status badge.

## Validation

- `golangci-lint run` → **0 issues**
- `go vet ./...`, `gofmt -l .` → clean
- `go test -race -cover ./...` → all pass (~88–93% coverage)
