### PR TITLE
Add Vivaldi to supported browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The open [Agent Skills standard](https://agentskills.io/clients) is supported by
 
 `gh-image` authenticates with your existing GitHub session — **no tokens to provision, no OAuth scopes to configure** for everyday local use. The tool reads the `user_session` cookie from your browser's encrypted cookie store.
 
-**Supported browsers:** Chrome · Brave · Chromium · Edge · Firefox · Opera · Safari
+**Supported browsers:** Chrome · Brave · Chromium · Edge · Firefox · Opera · Safari · Vivaldi
 
 **Supported platforms:** macOS · Linux · Windows
 

--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -74,7 +74,7 @@ Reads the GitHub `user_session` cookie from local browser cookie stores.
 - AES decryption and cookie DB schema differences across versions
 - Per-browser quirks for Chromium-family browsers, Firefox, Safari, and Opera
 
-**Supported browsers** (registered via blank-imported kooky finders): Chrome, Brave, Edge, Chromium, Firefox, Opera, Safari. `GetGitHubSession` queries all of them in one pass, groups the `user_session` candidates per browser store, and prefers stores that are logged in. When more than one candidate survives, `validate` is used to pick a live one (pass nil to skip network validation).
+**Supported browsers** (registered via blank-imported kooky finders): Chrome, Brave, Edge, Chromium, Firefox, Opera, Safari, Vivaldi. `GetGitHubSession` queries all of them in one pass, groups the `user_session` candidates per browser store, and prefers stores that are logged in. When more than one candidate survives, `validate` is used to pick a live one (pass nil to skip network validation).
 
 ```go
 // GetGitHubSession returns the best user_session cookie for github.com across

--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,8 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 	gopkg.in/ini.v1 v1.67.1 // indirect
 )
+
+// Temporary: Vivaldi support lives on a kooky fork until it is merged and
+// released upstream. Once released, bump the require above to that version and
+// delete this replace. Tracks browserutils/kooky#114.
+replace github.com/browserutils/kooky => github.com/Spence1115/kooky v0.0.0-20260710172612-8a5ccf70f944

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
+github.com/Spence1115/kooky v0.0.0-20260710172612-8a5ccf70f944 h1:5u+mEC1LKu7k0wfyg5Lix5BgGVXQ/swCxm3YvkHmuH8=
+github.com/Spence1115/kooky v0.0.0-20260710172612-8a5ccf70f944/go.mod h1:ndMF+xzEi4voUsZ4dX0BL45oompbf5wqBaKR+J3lUNk=
 github.com/browserutils/ese v0.0.0-20260314233042-37b6a03a93ce h1:xb/LXUukZgVLMRnTUyEiCfMNH7KUCFOS4aOZnc/N+H8=
 github.com/browserutils/ese v0.0.0-20260314233042-37b6a03a93ce/go.mod h1:Rj9TJxm7cExxJmdec83sr8cjvyF3raBsszTFviSo/6U=
-github.com/browserutils/kooky v0.2.10 h1:hEgbFJHf9lkMlSr0YdVEGtEo1yvqaTcGXNx0meNBgBA=
-github.com/browserutils/kooky v0.2.10/go.mod h1:ndMF+xzEi4voUsZ4dX0BL45oompbf5wqBaKR+J3lUNk=
 github.com/browserutils/sqlite3 v0.0.2 h1:RDSivmwoS5DauKYxh06G4Y+m6IX3da7Cq9Jh5x+oIUA=
 github.com/browserutils/sqlite3 v0.0.2/go.mod h1:3i7CY1ba3/D+qovGRJyCgfDnu/lGc8sg8ieM6jIUO50=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/cookies/cookies.go
+++ b/internal/cookies/cookies.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/browserutils/kooky/browser/firefox"
 	_ "github.com/browserutils/kooky/browser/opera"
 	_ "github.com/browserutils/kooky/browser/safari"
+	_ "github.com/browserutils/kooky/browser/vivaldi"
 )
 
 // NewSessionCookie builds a github.com user_session cookie from a raw value.

--- a/skills/github-image-upload/SKILL.md
+++ b/skills/github-image-upload/SKILL.md
@@ -47,7 +47,7 @@ Run these checks; only act on the ones that fail.
    - `--token <value>` flag, or
    - `GH_SESSION_TOKEN` env var (use this in CI / headless), or
    - the cookie store of a logged-in browser (Chrome/Brave/Chromium/Edge/Firefox/
-     Opera/Safari) — the default for local use. On macOS the first read may show a
+     Opera/Safari/Vivaldi) — the default for local use. On macOS the first read may show a
      Keychain prompt; the user should click **Always Allow**.
 
    > ⚠️ A `user_session` cookie grants **full account access** (it is not scoped


### PR DESCRIPTION
## Add Vivaldi to supported browsers

Registers kooky's Vivaldi finder (via a one-line blank import) so gh-image can extract a GitHub `user_session` cookie from Vivaldi, alongside the browsers already supported. Vivaldi is a mainstream Chromium-based browser that wasn't detected before.

### Draft — blocked on an upstream kooky release

Vivaldi support isn't in a released `kooky` yet. This PR depends on **browserutils/kooky#114**, consumed here through a temporary `replace` directive pointing at the fork:

```
replace github.com/browserutils/kooky => github.com/Spence1115/kooky <pseudo-version>
```

**This stays draft until that kooky PR merges and is released.** At that point: bump the `kooky` require to the released version and delete the `replace` directive (the go.mod comment notes this). CI here builds green against the fork in the meantime.

### Changes

- `internal/cookies/cookies.go` — blank-import `browser/vivaldi`. The existing selection logic is browser-agnostic, so nothing else changes functionally.
- Docs — add Vivaldi to the supported-browser lists in `README.md`, `documentation/architecture.md`, and the bundled skill.
- `go.mod` / `go.sum` — temporary fork replace (see above).

### Verification (macOS)

- `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run` (v2.12.2) all pass.
- `gh image check-token` authenticates via the browser cookie store.
- Confirmed the Vivaldi finder decrypts a real github.com `user_session` through this module's dependency graph (value not printed).

I can only verify the macOS key store at runtime; the Linux/Windows paths ride on kooky's existing per-OS decryption (see browserutils/kooky#114).
