### PR TITLE
Fix content_type detection for extensions GitHub rejects (#32)

### DIFF
--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -251,10 +251,42 @@ func renderMarkdown(name, href, contentType string) string {
 // githubContentType overrides Go's mime table for extensions whose
 // GitHub-expected content type differs from what mime.TypeByExtension reports.
 // GitHub validates the content_type against the file extension and rejects the
-// policy request (422) on a mismatch; e.g. it requires text/x-log for .log,
-// where Go reports text/plain.
+// policy request (422) on a mismatch.
+//
+// mime.TypeByExtension is unreliable here for two reasons: on Windows it reads
+// the registry, which can return legacy types (.jpg -> image/pjpeg); and for
+// many code/data extensions it returns nothing on every OS, so detectContentType
+// falls back to application/octet-stream, which GitHub rejects for text types.
+// Each value below was verified accepted (HTTP 201) against GitHub's policy
+// endpoint; the alternatives Go would otherwise send were verified rejected (422).
 var githubContentType = map[string]string{
+	// Windows registry emits legacy image/pjpeg or image/jpg for JPEG.
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	// Windows registry emits text/plain; GitHub also rejects application/javascript.
+	".js": "text/javascript",
+	// Go returns audio/x-wav / text/x-c, both rejected.
+	".wav": "audio/wav",
+	".cpp": "text/x-c++",
+	// Go returns video/mp2t for .ts (the MPEG-TS collision) on every OS.
+	".ts":  "text/typescript",
+	".tsx": "text/tsx",
+	// Go reports these but GitHub wants a different type.
 	".log": "text/x-log",
+	".sql": "application/sql",
+	".pdb": "application/octet-stream",
+	// Go has no mapping for these, so it falls back to application/octet-stream.
+	".md":         "text/markdown",
+	".jsonc":      "application/json",
+	".cs":         "text/x-csharp",
+	".php":        "text/x-php",
+	".py":         "text/x-python",
+	".patch":      "text/x-patch",
+	".cpuprofile": "application/json",
+	".ipynb":      "application/x-ipynb+json",
+	".yaml":       "application/x-yaml",
+	".yml":        "application/x-yaml",
+	".tgz":        "application/gzip",
 }
 
 func detectContentType(path string) string {

--- a/internal/upload/upload_test.go
+++ b/internal/upload/upload_test.go
@@ -411,9 +411,23 @@ func TestDetectContentType(t *testing.T) {
 	}{
 		{"a.png", "image/png"},
 		{"a.pdf", "application/pdf"},
-		{"notes.txt", "text/plain"},           // charset parameter stripped
-		{"server.log", "text/x-log"},          // GitHub override (Go reports text/plain)
-		{"SERVER.LOG", "text/x-log"},          // override is case-insensitive
+		{"notes.txt", "text/plain"},  // charset parameter stripped
+		{"server.log", "text/x-log"}, // GitHub override (Go reports text/plain)
+		{"SERVER.LOG", "text/x-log"}, // override is case-insensitive
+		// GitHub overrides, each verified accepted against the policy endpoint.
+		// Go would otherwise send a rejected type (or, for the empty-mapping
+		// extensions, application/octet-stream), causing a 422.
+		{"photo.jpg", "image/jpeg"},           // Windows: image/pjpeg / image/jpg
+		{"PHOTO.JPEG", "image/jpeg"},          // case-insensitive
+		{"app.js", "text/javascript"},         // Windows: text/plain
+		{"main.ts", "text/typescript"},        // Go: video/mp2t (all OSes)
+		{"app.tsx", "text/tsx"},               // Go: no mapping
+		{"README.md", "text/markdown"},        // Go: no mapping
+		{"script.py", "text/x-python"},        // Go: no mapping
+		{"config.yaml", "application/x-yaml"}, // Go: no mapping
+		{"config.yml", "application/x-yaml"},  // Go: no mapping
+		{"sound.wav", "audio/wav"},            // Go: audio/x-wav
+		{"lib.cpp", "text/x-c++"},             // Go: text/x-c
 		{"a.zzz", "application/octet-stream"}, // unknown extension
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #32.

## Problem

`detectContentType` relied on `mime.TypeByExtension`, whose output GitHub's upload policy endpoint (`POST /upload/policies/assets`) rejects with `422 content_type is not included in the list` for many extensions:

- **`.jpg` (the reported bug):** on Windows, Go's `mime` reads the registry, which commonly returns legacy `image/pjpeg` / `image/jpg`. GitHub only accepts `image/jpeg`. Renaming to `.jpeg` worked because that path yielded `image/jpeg`.
- **Broken on macOS/Linux too:** for several code/data extensions (`.md`, `.yaml`, `.yml`, `.jsonc`, `.cs`, `.php`, `.py`, `.patch`, `.cpuprofile`, `.ipynb`, `.tsx`, `.tgz`) Go's mime table returns nothing, so `detectContentType` fell back to `application/octet-stream`, which GitHub rejects for text types. Uploading these advertised file types failed on every platform.
- **Wrong values:** `.wav`→`audio/x-wav`, `.cpp`→`text/x-c`, `.ts`→`video/mp2t` (the well-known MPEG-TS collision), `.pdb`→`application/vnd.palm`, `.sql`→`application/x-sql` — all rejected.

## Fix

Expand the existing `githubContentType` override map (which previously held only `.log`) with 21 entries. **Each accepted value was verified against GitHub's live policy endpoint (HTTP 201), and the type Go would otherwise send was verified rejected (422).** Only extensions Go gets wrong are pinned; extensions whose mime value GitHub already accepts continue to use the `mime.TypeByExtension` fallback.

Notable verified mappings: `.ts`→`text/typescript`, `.tsx`→`text/tsx`, `.js`→`text/javascript` (GitHub rejects `application/javascript`), `.yaml`/`.yml`→`application/x-yaml` (GitHub rejects `text/yaml`).

## Testing

- Added cases to `TestDetectContentType` in `internal/upload/upload_test.go`.
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.