### PR TITLE
Add actionable Windows error hints for ABE and cookie locking (#30)

### DIFF
--- a/internal/cookies/cookies.go
+++ b/internal/cookies/cookies.go
@@ -71,8 +71,7 @@ var browserReadHints = []struct{ match, hint string }{
 		match: "being used by another process",
 		hint: "A running browser is locking its cookie database. Close the " +
 			"browser completely and try again, or set GH_SESSION_TOKEN to supply " +
-			"the cookie manually. " +
-			"See https://github.com/drogers0/gh-image/issues/5",
+			"the cookie manually.",
 	},
 	{
 		match: "decryption failed",
@@ -80,8 +79,7 @@ var browserReadHints = []struct{ match, hint string }{
 			"cookie decryption with App-Bound Encryption. Copy the github.com " +
 			"user_session cookie value from that browser's DevTools " +
 			"(F12 > Application > Cookies > github.com > user_session) and set " +
-			"GH_SESSION_TOKEN to it. " +
-			"See https://github.com/drogers0/gh-image/issues/4",
+			"GH_SESSION_TOKEN to it.",
 	},
 }
 

--- a/internal/cookies/cookies.go
+++ b/internal/cookies/cookies.go
@@ -47,6 +47,63 @@ type sessionCandidate struct {
 	loggedIn bool // a logged_in=yes cookie exists in the SAME store
 }
 
+// noSessionMsg is shown when no user_session cookie was found in any browser and
+// there was no read error. Defined once — used by both empty-candidate paths.
+const noSessionMsg = "no github.com user_session cookie found in any supported " +
+	"browser — are you logged into GitHub? Set GH_SESSION_TOKEN to supply the " +
+	"cookie manually, or log into GitHub in Chrome, Chromium, Edge, Firefox, " +
+	"Brave, Opera, or Safari."
+
+// browserReadHints maps a substring that may appear in a browser-read error to
+// actionable guidance. Matching is by substring, not errors.Is: the triggering
+// strings originate outside our code and are not exported sentinels —
+//   - "decryption failed" is a bare errors.New from kooky, confirmed present in
+//     v0.2.10 (browserutils/kooky/internal/chrome/chrome.go). Re-verify on bump.
+//   - "being used by another process" is the Windows sharing-violation OS string,
+//     taken verbatim from the captured output in issue #5. NOTE: this text is
+//     locale-dependent — non-English Windows won't match, which degrades to no
+//     hint (never a wrong hint), consistent with the wrap-not-replace rule below.
+//
+// We append hints rather than replace the error, so an upstream/OS wording change
+// degrades to the raw error instead of a wrong message. See issues #4 and #5.
+var browserReadHints = []struct{ match, hint string }{
+	{
+		match: "being used by another process",
+		hint: "A running browser is locking its cookie database. Close the " +
+			"browser completely and try again, or set GH_SESSION_TOKEN to supply " +
+			"the cookie manually. " +
+			"See https://github.com/drogers0/gh-image/issues/5",
+	},
+	{
+		match: "decryption failed",
+		hint: "A Chromium browser (Chrome 127+, Edge, Brave, or Opera) is blocking " +
+			"cookie decryption with App-Bound Encryption. Copy the github.com " +
+			"user_session cookie value from that browser's DevTools " +
+			"(F12 > Application > Cookies > github.com > user_session) and set " +
+			"GH_SESSION_TOKEN to it. " +
+			"See https://github.com/drogers0/gh-image/issues/4",
+	},
+}
+
+// annotateReadError wraps a browser-read error as "reading browser cookies" and
+// appends any actionable hints whose trigger substring is present. Pure and
+// unit-testable; the wrapping matches the previous inline behavior when no hint
+// matches. Precondition: err is non-nil (callers only invoke it on a read error).
+func annotateReadError(err error) error {
+	wrapped := fmt.Errorf("reading browser cookies: %w", err)
+	var hints []string
+	msg := err.Error()
+	for _, h := range browserReadHints {
+		if strings.Contains(msg, h.match) {
+			hints = append(hints, h.hint)
+		}
+	}
+	if len(hints) == 0 {
+		return wrapped
+	}
+	return fmt.Errorf("%w\nhint: %s", wrapped, strings.Join(hints, "\nhint: "))
+}
+
 // readRawCookies reads every valid github.com cookie across all supported
 // browsers/profiles and reduces each to a rawCookie. It is the only part of
 // selection that touches the real browser stores, so it is kept thin; the
@@ -154,7 +211,7 @@ func filterLoggedIn(cands []sessionCandidate) []sessionCandidate {
 // surface the authoritative error.
 func selectSession(cands []sessionCandidate, validate func(*http.Cookie) error) (*http.Cookie, error) {
 	if len(cands) == 0 {
-		return nil, fmt.Errorf("no github.com user_session cookie found in any supported browser — are you logged into GitHub?")
+		return nil, fmt.Errorf("%s", noSessionMsg)
 	}
 
 	// filterLoggedIn allocates; the fallback copies — so we never sort the
@@ -192,9 +249,9 @@ func chooseSession(raw []rawCookie, readErr error, validate func(*http.Cookie) e
 		// kooky reports errors for absent browsers/profiles alongside cookies
 		// from present ones; only surface the read error if nothing usable came back.
 		if readErr != nil {
-			return nil, fmt.Errorf("reading browser cookies: %w", readErr)
+			return nil, annotateReadError(readErr)
 		}
-		return nil, fmt.Errorf("no github.com user_session cookie found in any supported browser — are you logged into GitHub?")
+		return nil, fmt.Errorf("%s", noSessionMsg)
 	}
 	return selectSession(cands, validate)
 }

--- a/internal/cookies/cookies_test.go
+++ b/internal/cookies/cookies_test.go
@@ -161,7 +161,7 @@ func recordingValidator(dead ...string) (func(*http.Cookie) error, *[]string) {
 func TestAnnotateReadError(t *testing.T) {
 	t.Run("ABE only", func(t *testing.T) {
 		err := annotateReadError(fmt.Errorf("cookie store: chrome: decryption failed"))
-		for _, want := range []string{"reading browser cookies", "decryption failed", "hint:", "GH_SESSION_TOKEN", "issues/4"} {
+		for _, want := range []string{"reading browser cookies", "decryption failed", "hint:", "GH_SESSION_TOKEN", "App-Bound Encryption"} {
 			if !strings.Contains(err.Error(), want) {
 				t.Errorf("missing %q in %v", want, err)
 			}
@@ -170,7 +170,7 @@ func TestAnnotateReadError(t *testing.T) {
 
 	t.Run("lock only", func(t *testing.T) {
 		err := annotateReadError(fmt.Errorf("cookie store: open: The process cannot access the file because it is being used by another process."))
-		for _, want := range []string{"Close the browser", "issues/5"} {
+		for _, want := range []string{"Close the browser", "GH_SESSION_TOKEN"} {
 			if !strings.Contains(err.Error(), want) {
 				t.Errorf("missing %q in %v", want, err)
 			}

--- a/internal/cookies/cookies_test.go
+++ b/internal/cookies/cookies_test.go
@@ -158,6 +158,44 @@ func recordingValidator(dead ...string) (func(*http.Cookie) error, *[]string) {
 	}, &calls
 }
 
+func TestAnnotateReadError(t *testing.T) {
+	t.Run("ABE only", func(t *testing.T) {
+		err := annotateReadError(fmt.Errorf("cookie store: chrome: decryption failed"))
+		for _, want := range []string{"reading browser cookies", "decryption failed", "hint:", "GH_SESSION_TOKEN", "issues/4"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("missing %q in %v", want, err)
+			}
+		}
+	})
+
+	t.Run("lock only", func(t *testing.T) {
+		err := annotateReadError(fmt.Errorf("cookie store: open: The process cannot access the file because it is being used by another process."))
+		for _, want := range []string{"Close the browser", "issues/5"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("missing %q in %v", want, err)
+			}
+		}
+	})
+
+	t.Run("both present, lock hint first", func(t *testing.T) {
+		err := annotateReadError(fmt.Errorf("edge: being used by another process; chrome: decryption failed"))
+		msg := err.Error()
+		if got := strings.Count(msg, "hint:"); got != 2 {
+			t.Fatalf("expected 2 hints, got %d in %v", got, msg)
+		}
+		if strings.Index(msg, "Close the browser") > strings.Index(msg, "App-Bound Encryption") {
+			t.Errorf("expected lock hint before ABE hint, got %v", msg)
+		}
+	})
+
+	t.Run("no match leaves error untouched", func(t *testing.T) {
+		err := annotateReadError(fmt.Errorf("keyring locked"))
+		if got := err.Error(); got != "reading browser cookies: keyring locked" {
+			t.Errorf("expected bare wrap, got %q", got)
+		}
+	})
+}
+
 func TestChooseSession(t *testing.T) {
 	t.Run("empty raw with read error wraps it", func(t *testing.T) {
 		_, err := chooseSession(nil, fmt.Errorf("keyring locked"), nil)
@@ -166,10 +204,20 @@ func TestChooseSession(t *testing.T) {
 		}
 	})
 
+	t.Run("empty raw with ABE read error attaches hint", func(t *testing.T) {
+		_, err := chooseSession(nil, fmt.Errorf("cookie store: chrome: decryption failed"), nil)
+		if err == nil || !strings.Contains(err.Error(), "GH_SESSION_TOKEN") {
+			t.Fatalf("expected ABE hint mentioning GH_SESSION_TOKEN, got %v", err)
+		}
+	})
+
 	t.Run("empty raw without read error is the not-logged-in message", func(t *testing.T) {
 		_, err := chooseSession(nil, nil, nil)
 		if err == nil || !strings.Contains(err.Error(), "no github.com user_session cookie found") {
 			t.Fatalf("expected not-logged-in message, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "GH_SESSION_TOKEN") {
+			t.Errorf("expected not-logged-in message to mention GH_SESSION_TOKEN, got %v", err)
 		}
 	})
 

--- a/main.go
+++ b/main.go
@@ -345,7 +345,7 @@ func resolveSessionCookieWithGetter(tokenFlag, envToken string, getBrowserCookie
 	}
 	cookie, err := getBrowserCookie()
 	if err != nil {
-		return nil, "", fmt.Errorf("no session token found (set --token flag or GH_SESSION_TOKEN env var, or log into GitHub in a supported browser): %w", err)
+		return nil, "", fmt.Errorf("resolving session cookie: %w", err)
 	}
 	return cookie, "browser cookies", nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -130,8 +130,8 @@ func TestResolveSessionCookie_BrowserFallbackError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when browser getter fails, got nil")
 	}
-	if !strings.Contains(err.Error(), "no session token found") {
-		t.Errorf("expected 'no session token found' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "resolving session cookie") {
+		t.Errorf("expected 'resolving session cookie' in error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What & why

On Windows, browser-cookie reads fail with errors that give users no path to recovery, forcing them to dig through issues #4 and #5 for workarounds:

- `decryption failed` — kooky can't decrypt Chrome 127+ App-Bound Encryption (`v20`) cookies.
- `The process cannot access the file because it is being used by another process` — the OS lock when the browser is open.
- No `user_session` found — not logged in, or an undetected profile.

This is a **messaging-only** change (no new dependencies, no decryption/temp-copy work) — exactly what #30 asks for. It closes the UX gap behind #4, #5, and #30 together.

## How

- **Annotate at one seam.** A new `annotateReadError` attaches actionable hints to the browser-read error inside `chooseSession` — the only site reaching all three token paths (`resolveCookie`, `check-token`, `extract-token`). Matching is by **substring** (neither trigger is an exported sentinel), and hints are **appended, not substituted**, so an upstream/OS wording change degrades to today's raw error rather than a wrong message.
- **Hints** point users at `GH_SESSION_TOKEN` (with DevTools copy steps for ABE) and link issues #4/#5. The ABE hint is browser-neutral (Chrome/Edge/Brave/Opera all hit `v20`) and uses ASCII arrows to avoid mojibake on legacy Windows consoles.
- **Enriched not-logged-in message** names the supported browsers and the manual fallback, defined once as a shared const (removes a pre-existing duplicated literal).
- **Trimmed `main.go`'s outer wrapper** to a bare `resolving session cookie:` prefix so guidance is stated once, not duplicated over the cookies-layer message.

## Scope

Out of scope (unchanged): actual `v20` decryption (#4, upstream `kooky`), the temp-copy-DB fix for live locks (#5's own future work), and the `--cookie-path` flag (#31).

## Tests

- New `TestAnnotateReadError`: ABE-only, lock-only, both-present (asserts two hints, lock first), and no-match (bare wrap, original error preserved).
- Extended `TestChooseSession` (ABE hint wiring) and the not-logged-in assertion; updated the one `main_test.go` assertion affected by the wrapper trim.

Validation: `gofmt`, `go vet`, `go build`, `go test ./...`, and `golangci-lint run` all clean.

Closes #30.
