### PR TITLE
docs: non-standard browser profiles (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,7 @@ gh image --token "$MY_TOKEN" screenshot.png --repo owner/repo
 GH_SESSION_TOKEN="$MY_TOKEN" gh image screenshot.png --repo owner/repo
 
 # Non-standard browser not auto-detected (Firefox forks like Floorp/LibreWolf)?
-# Firefox-family browsers store cookie values in plaintext — read it directly:
-GH_SESSION_TOKEN="$(sqlite3 ~/path/to/profile/cookies.sqlite \
-  "SELECT value FROM moz_cookies WHERE name='user_session' AND host LIKE '%github.com'")" \
-  gh image screenshot.png --repo owner/repo
+GH_SESSION_TOKEN="$(sqlite3 ~/path/to/profile/cookies.sqlite "SELECT value FROM moz_cookies WHERE name='user_session' AND host LIKE '%github.com'")" gh image screenshot.png --repo owner/repo
 ```
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ For CI, headless environments, or shared machines, you can supply the session to
 | Priority | Source | When to use |
 |---|---|---|
 | 1 | `--token <value>` flag | One-off invocations |
-| 2 | `GH_SESSION_TOKEN` env var | CI/CD, shared machines |
+| 2 | `GH_SESSION_TOKEN` env var | CI/CD, shared machines, non-standard browsers |
 | 3 | Browser cookie store | Local interactive use (default) |
 
 ```bash
@@ -128,11 +128,9 @@ gh image --token "$MY_TOKEN" screenshot.png --repo owner/repo
 
 # Environment variable (preferred — not visible to `ps aux`)
 GH_SESSION_TOKEN="$MY_TOKEN" gh image screenshot.png --repo owner/repo
-```
 
-**Non-standard browser profiles** (Firefox forks like Floorp/LibreWolf, or a profile in an unusual path) may not be auto-detected. Firefox-family browsers store cookie values in plaintext, so read the token straight from the profile:
-
-```bash
+# Non-standard browser not auto-detected (Firefox forks like Floorp/LibreWolf)?
+# Firefox-family browsers store cookie values in plaintext — read it directly:
 GH_SESSION_TOKEN="$(sqlite3 ~/path/to/profile/cookies.sqlite \
   "SELECT value FROM moz_cookies WHERE name='user_session' AND host LIKE '%github.com'")" \
   gh image screenshot.png --repo owner/repo

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ gh image --token "$MY_TOKEN" screenshot.png --repo owner/repo
 GH_SESSION_TOKEN="$MY_TOKEN" gh image screenshot.png --repo owner/repo
 
 # Non-standard browser not auto-detected (Firefox forks like Floorp/LibreWolf)?
-GH_SESSION_TOKEN="$(sqlite3 ~/path/to/profile/cookies.sqlite "SELECT value FROM moz_cookies WHERE name='user_session' AND host LIKE '%github.com'")" gh image screenshot.png --repo owner/repo
+GH_SESSION_TOKEN="$(sqlite3 ~/path/to/profile/cookies.sqlite "SELECT value FROM moz_cookies WHERE name='user_session' AND host LIKE '%github.com'")" \
+  gh image screenshot.png --repo owner/repo
 ```
 
 > [!WARNING]

--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ gh image --token "$MY_TOKEN" screenshot.png --repo owner/repo
 GH_SESSION_TOKEN="$MY_TOKEN" gh image screenshot.png --repo owner/repo
 ```
 
+**Non-standard browser profiles** (Firefox forks like Floorp/LibreWolf, or a profile in an unusual path) may not be auto-detected. Firefox-family browsers store cookie values in plaintext, so read the token straight from the profile:
+
+```bash
+GH_SESSION_TOKEN="$(sqlite3 ~/path/to/profile/cookies.sqlite \
+  "SELECT value FROM moz_cookies WHERE name='user_session' AND host LIKE '%github.com'")" \
+  gh image screenshot.png --repo owner/repo
+```
+
 > [!WARNING]
 > `user_session` cookies grant **full account access** — they are not scoped like personal access tokens. Treat them with the same care as a password. If leaked, **[sign out of GitHub](https://github.com/logout)** on the machine that holds the session; if you are not on that machine, revoke it through [Settings → Sessions](https://github.com/settings/sessions), or [change your password](https://github.com/settings/security) (which kills every session in one action).
 


### PR DESCRIPTION
Rescopes #31 from a `--cookie-path` flag to a docs note, per discussion on the issue.

Adds a minimal **Non-standard browser profiles** note to the Session token override section: Firefox-family browsers (incl. forks like Floorp/LibreWolf) store cookie values in plaintext, so a profile in an unusual path can be read straight into `GH_SESSION_TOKEN` — no new flag or auth-resolution source needed.

Refs #31.