### PR TITLE
docs: add "Who's using gh-image" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,43 @@ npx skills add drogers0/gh-image
 
 The open [Agent Skills standard](https://agentskills.io/clients) is supported by **Claude Code**, **OpenAI Codex**, **Cursor**, **GitHub Copilot**, and [many more](https://agentskills.io/clients). The skill walks the agent through installing this extension (if needed), running the upload, and embedding the resulting `user-attachments` URL into a PR, issue, or comment.
 
+## Who's using gh-image
+
+Shipping visual evidence in production review pipelines:
+
+<table width="100%">
+<tr>
+<td valign="top">
+
+<a href="https://github.com/NousResearch/hermes-agent"><img src="https://avatars.githubusercontent.com/u/134168893?s=48&v=4" width="18" align="top"></a> &nbsp;<b><a href="https://github.com/NousResearch/hermes-agent/blob/main/.github/workflows/publish-e2e-evidence.yml">NousResearch/hermes-agent</a></b> &nbsp;<code>&#9733; 220k+</code>
+<br><br>
+Automated <b>visual proof on every single pull request</b>, with no human in the loop: the <a href="https://github.com/NousResearch/hermes-agent/blob/main/.github/workflows/publish-e2e-evidence.yml">publish job</a> uploads the E2E screenshots inline using a specially scoped attachment bot account.
+
+</td>
+</tr>
+</table>
+
+<table width="100%">
+<tr>
+<td width="50%" valign="top">
+
+<a href="https://github.com/openshift/console"><img src="https://avatars.githubusercontent.com/u/792337?s=48&v=4" width="18" align="top"></a> &nbsp;<b><a href="https://github.com/openshift/console/blob/main/.claude/skills/qa-verify/scripts/upload-evidence.sh">openshift/console</a></b><br>
+<code>&#9733; 450+</code> &nbsp;&middot;&nbsp; Red Hat
+<br><br>
+Its <code>/qa-verify</code> agent skill hands reviewers <b>full-resolution QA evidence</b> &mdash; CDN-hosted, so nothing gets downscaled to fit a comment.
+
+</td>
+<td width="50%" valign="top">
+
+<a href="https://github.com/Simpleyyt/ai-manus"><img src="https://avatars.githubusercontent.com/u/2818827?s=48&v=4" width="18" align="top"></a> &nbsp;<b><a href="https://github.com/Simpleyyt/ai-manus/blob/main/.cursor/skills/demo-videos/SKILL.md">Simpleyyt/ai-manus</a></b><br>
+<code>&#9733; 1.5k+</code>
+<br><br>
+A <code>demo-videos</code> skill publishes the <b>README demo reels</b> &mdash; <code>gh image</code> is mandatory, since only <code>user-attachments</code> URLs autoplay inline.
+
+</td>
+</tr>
+</table>
+
 ## Authentication
 
 `gh-image` authenticates with your existing GitHub session — **no tokens to provision, no OAuth scopes to configure** for everyday local use. The tool reads the `user_session` cookie from your browser's encrypted cookie store.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Shipping visual evidence in production review pipelines:
 <tr>
 <td valign="top">
 
-<a href="https://github.com/NousResearch/hermes-agent"><img src="https://avatars.githubusercontent.com/u/134168893?s=48&v=4" width="18" align="top"></a> &nbsp;<b><a href="https://github.com/NousResearch/hermes-agent/blob/main/.github/workflows/publish-e2e-evidence.yml">NousResearch/hermes-agent</a></b> &nbsp;<code>&#9733; 220k+</code>
+<a href="https://github.com/NousResearch/hermes-agent"><img src="https://avatars.githubusercontent.com/u/134168893?s=48&v=4" width="18" align="top"></a> &nbsp;<b><a href="https://github.com/NousResearch/hermes-agent/blob/main/.github/workflows/publish-e2e-evidence.yml">NousResearch/hermes-agent</a></b> &nbsp;<code>&#9733; 226k+</code>
 <br><br>
 Automated <b>visual proof on every single pull request</b>, with no human in the loop: the <a href="https://github.com/NousResearch/hermes-agent/blob/main/.github/workflows/publish-e2e-evidence.yml">publish job</a> uploads the E2E screenshots inline using a specially scoped attachment bot account.
 
@@ -128,7 +128,7 @@ Its <code>/qa-verify</code> agent skill hands reviewers <b>full-resolution QA ev
 <td width="50%" valign="top">
 
 <a href="https://github.com/Simpleyyt/ai-manus"><img src="https://avatars.githubusercontent.com/u/2818827?s=48&v=4" width="18" align="top"></a> &nbsp;<b><a href="https://github.com/Simpleyyt/ai-manus/blob/main/.cursor/skills/demo-videos/SKILL.md">Simpleyyt/ai-manus</a></b><br>
-<code>&#9733; 1.5k+</code>
+<code>&#9733; 1.6k+</code>
 <br><br>
 A <code>demo-videos</code> skill publishes the <b>README demo reels</b> &mdash; <code>gh image</code> is mandatory, since only <code>user-attachments</code> URLs autoplay inline.
 


### PR DESCRIPTION
Adds a `Who's using gh-image` section between **Use with AI agents** and **Authentication**, showcasing three projects that run `gh-image` in their review and documentation pipelines.

## Entries

| Project | Usage site | How they use it |
|---|---|---|
| **NousResearch/hermes-agent** `★ 220k+` | [`publish-e2e-evidence.yml`](https://github.com/NousResearch/hermes-agent/blob/main/.github/workflows/publish-e2e-evidence.yml) | Posts E2E screenshots inline on every PR from CI, unattended, via a dedicated attachment bot account scoped to that repo |
| **openshift/console** `★ 450+` (Red Hat) | [`upload-evidence.sh`](https://github.com/openshift/console/blob/main/.claude/skills/qa-verify/scripts/upload-evidence.sh) | Its `/qa-verify` agent skill uploads full-resolution QA evidence for reviewers |
| **Simpleyyt/ai-manus** `★ 1.5k+` | [`demo-videos/SKILL.md`](https://github.com/Simpleyyt/ai-manus/blob/main/.cursor/skills/demo-videos/SKILL.md) | A `demo-videos` skill publishes the README demo reels |

## Verification

Every claim was checked against source rather than taken on trust:

- All three repositories confirmed to exist, with star counts read from the API. Badges use `220k+` / `450+` / `1.5k+` so they stay accurate as the repos grow.
- Each usage site was read directly; descriptions reflect what the code and skill files actually do.
- All six outbound links return HTTP 200.
- The hermes-agent bot-account detail comes from that PR's own description: *"The attachment bot is a dedicated account limited to this repository."*
- The rendered output was verified through GitHub's `/markdown` API to confirm the layout survives HTML sanitization.

## Layout notes

- **Two single-row HTML tables, not one two-row table.** GitHub's stylesheet shades even-numbered rows (`tr:nth-child(2n)`), which tinted the second row's background. Inline `style` is stripped so it cannot be overridden, but one row per table keeps every row at `nth-child(1)` and unshaded. Both carry `width="100%"` so the two boxes align (GitHub sizes tables to `max-content` otherwise).
- **HTML, not markdown.** Inline `style` is stripped, so CSS grid is impossible; tables are the only way to get column alignment. `border="0"` is also stripped, so cell gridlines are unavoidable.
- **Cell content is plain HTML** (`<b>`, `<code>`, `<a>`) because markdown is not reliably processed inside `<td>` — backticks and `**` would render literally.
- **Logos are wrapped in repo links.** GitHub otherwise auto-links a bare image to the raw avatar file, so clicking a logo would open the image instead of the project.
- **Stars use `&#9733;`** rather than a literal `★`, so the character cannot be mangled by editor encoding.
- Row 1 is a full-width hero card; row 2 holds two balanced cards (descriptions within 3 characters of each other, so they render at the same height).

If a fourth project is added later, drop the `colspan="2"` on row 1 to make a clean 2×2.
