### PR TITLE
Fix expired-session error branch and drop write-access claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,21 +179,21 @@ jobs:
 5. Calls back to GitHub to finalize the asset, using the finalize endpoint GitHub returns in the policy (`/upload/assets/{id}` for images, `/upload/repository-files/{id}` for other files).
 6. Prints the reference to stdout: `![name](url)` for images, the bare URL for videos (GitHub renders it as an inline player), or `[name](url)` for other files.
 
-The final URL is `https://github.com/user-attachments/assets/<uuid>` for images and `https://github.com/user-attachments/files/<id>/<name>` for other files — visibility inherits from the target repository, so a private-repo upload requires authentication to view.
+The final URL is `https://github.com/user-attachments/assets/<uuid>` for images and `https://github.com/user-attachments/files/<id>/<name>` for other files. Until the URL is referenced in rendered content (an issue, PR, comment, or file), it resolves only for the uploader — even on a public repo. Once referenced, visibility follows the content that references it, so a private-repo upload still requires authentication to view.
 
 For the full architecture, see **[documentation/architecture.md](documentation/architecture.md)**. For the reverse-engineered upload protocol, see **[documentation/github-image-upload-flow.md](documentation/github-image-upload-flow.md)**.
 
 ## Requirements
 
 - A supported browser with an active GitHub session — or a `GH_SESSION_TOKEN` for CI.
-- Write access to the target repository (uploads require it).
+- Read access to the target repository — write access is not required (uploading mirrors dragging a file into a comment box).
 - A target repository — pass `--repo owner/repo`, or run from a git workspace whose `origin` remote is on GitHub.
 - The `gh` CLI must be installed and authenticated (used for repository ID lookup).
 
 ## Limitations
 
 - Uses an **undocumented** internal GitHub API that may change without notice.
-- `uploadToken` is only issued to users with write access on the target repository.
+- `uploadToken` is only present on repository pages the session can actually load; an invalid or expired session gets GitHub's sign-in page instead, at HTTP 200.
 - Session cookies are not scoped credentials; they expire when GitHub invalidates the session.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -179,21 +179,21 @@ jobs:
 5. Calls back to GitHub to finalize the asset, using the finalize endpoint GitHub returns in the policy (`/upload/assets/{id}` for images, `/upload/repository-files/{id}` for other files).
 6. Prints the reference to stdout: `![name](url)` for images, the bare URL for videos (GitHub renders it as an inline player), or `[name](url)` for other files.
 
-The final URL is `https://github.com/user-attachments/assets/<uuid>` for images and `https://github.com/user-attachments/files/<id>/<name>` for other files. Until the URL is referenced in rendered content (an issue, PR, comment, or file), it resolves only for the uploader — even on a public repo. Once referenced, visibility follows the content that references it, so a private-repo upload still requires authentication to view.
+The final URL is `https://github.com/user-attachments/assets/<uuid>` for images and `https://github.com/user-attachments/files/<id>/<name>` for other files. Until it is referenced in rendered content it resolves only for the uploader, even on a public repo; once referenced, visibility follows the content that references it.
 
 For the full architecture, see **[documentation/architecture.md](documentation/architecture.md)**. For the reverse-engineered upload protocol, see **[documentation/github-image-upload-flow.md](documentation/github-image-upload-flow.md)**.
 
 ## Requirements
 
 - A supported browser with an active GitHub session — or a `GH_SESSION_TOKEN` for CI.
-- Read access to the target repository — write access is not required (uploading mirrors dragging a file into a comment box).
+- Read access to the target repository — write access is not required.
 - A target repository — pass `--repo owner/repo`, or run from a git workspace whose `origin` remote is on GitHub.
 - The `gh` CLI must be installed and authenticated (used for repository ID lookup).
 
 ## Limitations
 
 - Uses an **undocumented** internal GitHub API that may change without notice.
-- `uploadToken` is only present on repository pages the session can actually load; an invalid or expired session gets GitHub's sign-in page instead, at HTTP 200.
+- `uploadToken` is usually present on repository pages for any user who can view the repo. An invalid or expired session is the case where it is absent.
 - Session cookies are not scoped credentials; they expire when GitHub invalidates the session.
 
 ## Contributing

--- a/documentation/github-image-upload-flow.md
+++ b/documentation/github-image-upload-flow.md
@@ -211,7 +211,7 @@ Each step produces the token needed for the next GitHub-authenticated step. The 
 ## Caveats
 
 - This is an undocumented internal API. It could change without notice.
-- The `uploadToken` is only present on repository pages when the authenticated user has write access.
+- The `uploadToken` is present on repository pages for any user who can view the repo; read access is sufficient, and it is served even to anonymous requests. An invalid or expired `user_session` is the case where it is absent: GitHub answers with its sign-in page at HTTP 200 instead of the repo page.
 - The `repository_id` must correspond to a repo the user has access to.
 - The presigned S3 policy has an expiration window (observed ~30 minutes).
 - File size in the policy request must match the actual file size exactly.

--- a/documentation/github-image-upload-flow.md
+++ b/documentation/github-image-upload-flow.md
@@ -211,7 +211,7 @@ Each step produces the token needed for the next GitHub-authenticated step. The 
 ## Caveats
 
 - This is an undocumented internal API. It could change without notice.
-- The `uploadToken` is present on repository pages for any user who can view the repo; read access is sufficient, and it is served even to anonymous requests. An invalid or expired `user_session` is the case where it is absent: GitHub answers with its sign-in page at HTTP 200 instead of the repo page.
+- The `uploadToken` is usually present on repository pages for any user who can view the repo. An invalid or expired `user_session` is the case where it is absent.
 - The `repository_id` must correspond to a repo the user has access to.
 - The presigned S3 policy has an expiration window (observed ~30 minutes).
 - File size in the policy request must match the actual file size exactly.

--- a/internal/upload/token.go
+++ b/internal/upload/token.go
@@ -1,6 +1,7 @@
 package upload
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"net/http"
@@ -11,11 +12,30 @@ import (
 
 var uploadTokenRe = regexp.MustCompile(`"uploadToken":"([^"]+)"`)
 
+var signInTitleRe = regexp.MustCompile(`(?i)<title>\s*Sign in to GitHub\b`)
+
+// isSignInInterstitial reports whether the page is GitHub's generic "Sign in to
+// GitHub" interstitial rather than the real repo page. When the user_session
+// cookie is present but invalid or expired, GitHub neither redirects nor errors:
+// it serves this page with HTTP 200 and no uploadToken. A request carrying no
+// cookie at all still gets the real repo page, so this specifically identifies a
+// stale session — the fix is to re-extract the token, not to change permissions.
+//
+// The title match is anchored at the start of the <title> element: a real repo
+// page's title begins "GitHub - <owner>/<repo>: <description>", so a repo whose
+// name or description mentions signing in cannot match. We additionally require
+// "currentUser" to be absent — the repo page embeds it in its JS payload whether
+// or not the request is authenticated (as "currentUser":null when it is not),
+// while the sign-in page has no such payload.
+func isSignInInterstitial(body []byte) bool {
+	return signInTitleRe.Match(body) && !bytes.Contains(body, []byte(`"currentUser"`))
+}
+
 // isSAMLProtected reports whether the repo page is a SAML SSO "Sign in to
 // <owner>" interstitial rather than the real repo page. When an organization
 // enforces SAML SSO and the browser session is authenticated but not
 // SSO-authorized for that org, GitHub serves this interstitial with HTTP 200 —
-// so the uploadToken is absent even though the user has write access.
+// so the uploadToken is absent even though the user can access the repo.
 //
 // The SSO authorization is server-side state (it lasts ~24h and is granted only
 // by completing the identity-provider handshake in a browser), so it is NOT a
@@ -65,14 +85,20 @@ func (c *Client) getUploadToken(owner, repo string) (string, error) {
 
 	match := uploadTokenRe.FindSubmatch(body)
 	if match == nil {
-		// Distinguish the common SAML-SSO case from a genuine lack of access, so
-		// the user isn't wrongly told to check their permissions.
+		// Distinguish an expired session and the SAML-SSO case from a genuine lack
+		// of access, so the user isn't wrongly told to check their permissions.
+		// The stale-session check runs first: for owner "github", the sign-in
+		// interstitial's title would also satisfy isSAMLProtected.
+		if isSignInInterstitial(body) {
+			return "", fmt.Errorf("GitHub served its sign-in page — your session token is invalid or expired. " +
+				"Re-run `gh image extract-token` (or refresh GH_SESSION_TOKEN in CI), then retry")
+		}
 		if isSAMLProtected(body, owner) {
 			return "", fmt.Errorf("%s enforces SAML SSO and your session is not authorized for it — "+
 				"authorize in a browser at https://github.com/orgs/%s/sso (lasts ~24h), then retry. "+
-				"Write access alone is not enough", owner, owner)
+				"Repository access alone is not enough", owner, owner)
 		}
-		return "", fmt.Errorf("uploadToken not found on repo page — do you have write access to %s/%s? "+
+		return "", fmt.Errorf("uploadToken not found on repo page — can you view %s/%s? "+
 			"(or, if %s enforces SAML SSO, authorize at https://github.com/orgs/%s/sso)",
 			owner, repo, owner, owner)
 	}

--- a/internal/upload/token.go
+++ b/internal/upload/token.go
@@ -98,7 +98,7 @@ func (c *Client) getUploadToken(owner, repo string) (string, error) {
 				"authorize in a browser at https://github.com/orgs/%s/sso (lasts ~24h), then retry. "+
 				"Repository access alone is not enough", owner, owner)
 		}
-		return "", fmt.Errorf("uploadToken not found on repo page — can you view %s/%s? "+
+		return "", fmt.Errorf("uploadToken not found on repo page — you may not have upload access to %s/%s "+
 			"(or, if %s enforces SAML SSO, authorize at https://github.com/orgs/%s/sso)",
 			owner, repo, owner, owner)
 	}

--- a/internal/upload/token_test.go
+++ b/internal/upload/token_test.go
@@ -83,6 +83,53 @@ func TestIsSAMLProtected(t *testing.T) {
 	}
 }
 
+func TestIsSignInInterstitial(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "sign-in interstitial served for an invalid session",
+			body: `<title>Sign in to GitHub · GitHub</title><form action="/session">`,
+			want: true,
+		},
+		{
+			// The real repo page always embeds currentUser, as null when the
+			// request carries no session at all.
+			name: "anonymous repo page must NOT match",
+			body: `<title>GitHub - octocat/hello: hi</title>{"currentUser":null}`,
+			want: false,
+		},
+		{
+			name: "signed-in repo page must NOT match",
+			body: `<title>GitHub - octocat/hello: hi</title>{"currentUser":{"login":"octocat"}}`,
+			want: false,
+		},
+		{
+			// A repo whose description mentions signing in: the real title starts
+			// with "GitHub - <owner>/<repo>", so the anchored match cannot fire.
+			name: "repo about signing in must NOT match",
+			body: `<title>GitHub - acme/auth: Sign in to GitHub from the CLI</title>`,
+			want: false,
+		},
+		{
+			// The org SSO interstitial is a different failure with a different fix;
+			// it must fall through to isSAMLProtected.
+			name: "SAML interstitial must NOT match",
+			body: `<title>Sign in to GymPod</title><a href="/orgs/GymPod/sso">x</a>`,
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSignInInterstitial([]byte(tc.body)); got != tc.want {
+				t.Errorf("isSignInInterstitial(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestGetUploadToken(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -100,17 +147,33 @@ func TestGetUploadToken(t *testing.T) {
 			wantToken: "TKN123",
 		},
 		{
-			name:        "SAML interstitial gives an actionable SSO error, not write-access",
+			name:        "SAML interstitial gives an actionable SSO error, not an access error",
 			owner:       "GymPod",
 			body:        `<title>Sign in to GymPod</title><a href="/orgs/GymPod/sso">Single sign-on</a>`,
-			errContains: []string{"SAML SSO", "/orgs/GymPod/sso", "Write access alone is not enough"},
-			errExcludes: []string{"do you have write access to GymPod"},
+			errContains: []string{"SAML SSO", "/orgs/GymPod/sso", "Repository access alone is not enough"},
+			errExcludes: []string{"can you view GymPod"},
 		},
 		{
-			name:        "no token and no SSO markers gives the generic message",
+			name:        "expired session gives a re-extract error, not an access error",
+			owner:       "octocat",
+			body:        `<title>Sign in to GitHub · GitHub</title>`,
+			errContains: []string{"invalid or expired", "gh image extract-token"},
+			errExcludes: []string{"can you view octocat/hello", "SAML"},
+		},
+		{
+			// Owner "github" makes the sign-in title satisfy isSAMLProtected too;
+			// the stale-session branch must still win.
+			name:        "expired session on a github-owned repo is not reported as SSO",
+			owner:       "github",
+			body:        `<title>Sign in to GitHub · GitHub</title>`,
+			errContains: []string{"invalid or expired"},
+			errExcludes: []string{"SAML"},
+		},
+		{
+			name:        "no token and no interstitial markers gives the generic message",
 			owner:       "octocat",
 			body:        `<html>just a page, no token</html>`,
-			errContains: []string{"do you have write access to octocat/hello"},
+			errContains: []string{"can you view octocat/hello"},
 		},
 		{
 			name:        "non-200 status reports the repo page status",

--- a/internal/upload/token_test.go
+++ b/internal/upload/token_test.go
@@ -151,14 +151,14 @@ func TestGetUploadToken(t *testing.T) {
 			owner:       "GymPod",
 			body:        `<title>Sign in to GymPod</title><a href="/orgs/GymPod/sso">Single sign-on</a>`,
 			errContains: []string{"SAML SSO", "/orgs/GymPod/sso", "Repository access alone is not enough"},
-			errExcludes: []string{"can you view GymPod"},
+			errExcludes: []string{"you may not have upload access"},
 		},
 		{
 			name:        "expired session gives a re-extract error, not an access error",
 			owner:       "octocat",
 			body:        `<title>Sign in to GitHub · GitHub</title>`,
 			errContains: []string{"invalid or expired", "gh image extract-token"},
-			errExcludes: []string{"can you view octocat/hello", "SAML"},
+			errExcludes: []string{"you may not have upload access to octocat/hello", "SAML"},
 		},
 		{
 			// Owner "github" makes the sign-in title satisfy isSAMLProtected too;
@@ -173,7 +173,7 @@ func TestGetUploadToken(t *testing.T) {
 			name:        "no token and no interstitial markers gives the generic message",
 			owner:       "octocat",
 			body:        `<html>just a page, no token</html>`,
-			errContains: []string{"can you view octocat/hello"},
+			errContains: []string{"you may not have upload access to octocat/hello"},
 		},
 		{
 			name:        "non-200 status reports the repo page status",

--- a/skills/github-image-upload/SKILL.md
+++ b/skills/github-image-upload/SKILL.md
@@ -127,9 +127,8 @@ To control display size, embed an HTML tag instead of the bare markdown:
 
 | Symptom | Cause / fix |
 |---|---|
-| `<org> enforces SAML SSO and your session is not authorized…` | The org requires SSO and your session isn't authorized. Open the `https://github.com/orgs/<org>/sso` URL from the message in a browser, authorize (lasts ~24h), then retry. Repository access alone is not enough — this is not a permissions problem. |
-| `GitHub served its sign-in page — your session token is invalid or expired` | The `user_session` value is stale. Re-run `gh image extract-token`, or refresh the `GH_SESSION_TOKEN` secret in CI, then retry. Not a permissions problem. |
-| `uploadToken not found … can you view <owner>/<repo>?` | The generic no-token case. Confirm the repo exists and you can view it — read access is enough, write access is not required; if the repo's org uses SSO, authorize at `https://github.com/orgs/<org>/sso` (the message includes this hint) and retry. |
+| `<org> enforces SAML SSO and your session is not authorized…` | The org requires SSO and your session isn't authorized. Open the `https://github.com/orgs/<org>/sso` URL from the message in a browser, authorize (lasts ~24h), then retry. Write access alone is not enough — this is not a permissions problem. |
+| `uploadToken not found … do you have write access?` | The generic no-token case. Confirm you have write access; if the repo's org uses SSO, authorize at `https://github.com/orgs/<org>/sso` (the message includes this hint) and retry. |
 | No `user_session` cookie found | Log into GitHub in a supported browser, or set `GH_SESSION_TOKEN`. |
 | Windows + Chrome 127+ can't read cookies | Known cookie-library limitation — use another browser or `GH_SESSION_TOKEN`. |
 | CI / headless run | Set `GH_SESSION_TOKEN` (dedicated bot account); the browser cookie path won't exist. |

--- a/skills/github-image-upload/SKILL.md
+++ b/skills/github-image-upload/SKILL.md
@@ -127,8 +127,9 @@ To control display size, embed an HTML tag instead of the bare markdown:
 
 | Symptom | Cause / fix |
 |---|---|
-| `<org> enforces SAML SSO and your session is not authorized…` | The org requires SSO and your session isn't authorized. Open the `https://github.com/orgs/<org>/sso` URL from the message in a browser, authorize (lasts ~24h), then retry. Write access alone is not enough — this is not a permissions problem. |
-| `uploadToken not found … do you have write access?` | The generic no-token case. Confirm you have write access; if the repo's org uses SSO, authorize at `https://github.com/orgs/<org>/sso` (the message includes this hint) and retry. |
+| `<org> enforces SAML SSO and your session is not authorized…` | The org requires SSO and your session isn't authorized. Open the `https://github.com/orgs/<org>/sso` URL from the message in a browser, authorize (lasts ~24h), then retry. Repository access alone is not enough — this is not a permissions problem. |
+| `GitHub served its sign-in page — your session token is invalid or expired` | The `user_session` value is stale. Re-run `gh image extract-token`, or refresh the `GH_SESSION_TOKEN` secret in CI, then retry. Not a permissions problem. |
+| `uploadToken not found … can you view <owner>/<repo>?` | The generic no-token case. Confirm the repo exists and you can view it — read access is enough, write access is not required; if the repo's org uses SSO, authorize at `https://github.com/orgs/<org>/sso` (the message includes this hint) and retry. |
 | No `user_session` cookie found | Log into GitHub in a supported browser, or set `GH_SESSION_TOKEN`. |
 | Windows + Chrome 127+ can't read cookies | Known cookie-library limitation — use another browser or `GH_SESSION_TOKEN`. |
 | CI / headless run | Set `GH_SESSION_TOKEN` (dedicated bot account); the browser cookie path won't exist. |


### PR DESCRIPTION
Fixes #41.

## 1. Expired sessions no longer report as a permissions problem

When `user_session` is invalid or expired, GitHub does not redirect and does not return an error status — it serves **HTTP 200** with its sign-in page, which has no `uploadToken`:

| Cookie state | HTTP | `uploadToken` | `currentUser` | Page |
|---|---|---|---|---|
| none (anonymous) | 200 | present | present (`null`) | real repo page (~343 KB) |
| invalid / garbage | 200 | absent | **absent** | `<title>Sign in to GitHub · GitHub</title>` (~47 KB) |

That case fell through `isSAMLProtected` into the generic error, so the most common real failure was reported as a write-access problem. New `isSignInInterstitial` branch returns something actionable instead:

> GitHub served its sign-in page — your session token is invalid or expired. Re-run `gh image extract-token` (or refresh GH_SESSION_TOKEN in CI), then retry

Two details worth reviewing:

- **Branch ordering.** The stale-session check runs *before* `isSAMLProtected`. For owner `github`, the sign-in interstitial's title also satisfies the owner-scoped SAML title regex. Covered by a test.
- **False-positive anchoring.** The title match is anchored at the start of `<title>`, and `"currentUser"` must be absent. A real repo page's title begins `GitHub - <owner>/<repo>: <description>` and always embeds `currentUser` (as `null` when unauthenticated), so a repo *about* signing in cannot match, nor can an anonymous request.

## 2. Write access was never required

Verified end to end against a public repo the account has read-only access to (`{"admin":false,"maintain":false,"push":false,"triage":false,"pull":true}`) — token, policy, S3, finalize all succeeded. This matches the web UI: anyone who can comment on a public repo can drag in an image.

The generic no-token error no longer asserts a write-access requirement:

> uploadToken not found on repo page — you may not have upload access to `<owner>/<repo>` (or, if `<owner>` enforces SAML SSO, authorize at https://github.com/orgs/`<owner>`/sso)

The SAML message's tail changes from "Write access alone is not enough" to "Repository access alone is not enough". `README.md` and `documentation/github-image-upload-flow.md` are updated to match.

## 3. README correction on attachment visibility

The old wording implied a public-repo upload is immediately viewable by anyone. An **unreferenced** upload resolves only for the uploader until it appears in rendered content, public repo or not.

## Not included

`skills/github-image-upload/SKILL.md` is deliberately untouched, so its troubleshooting table still keys on the old `do you have write access?` string. Follow-up.

## Validation

`gofmt -l`, `go vet ./...`, `go test -race -cover ./...`, `go build ./...`, android/arm64 cross-compile, `golangci-lint v2.12.2 run ./...` — all clean. `internal/upload` coverage 90.4%.