### PR TITLE
Try bearer-token upload before the browser-session flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ A <code>demo-videos</code> skill publishes the <b>README demo reels</b> &mdash; 
 
 `gh-image` authenticates with your existing GitHub session — **no tokens to provision, no OAuth scopes to configure** for everyday local use. The tool reads the `user_session` cookie from your browser's encrypted cookie store.
 
+Images and video going to a repository you can push to are uploaded with your `gh` CLI token instead, and never touch the browser cookie store. Everything else — other file types, and repositories you cannot push to — uses the session below.
+
 **Supported browsers:** Chrome · Brave · Chromium · Edge · Firefox · Opera · Safari
 
 **Supported platforms:** macOS · Linux · Windows · Android (Termux)
@@ -164,7 +166,7 @@ On macOS, a Keychain prompt may appear on first use to authorize access to your 
 
 ### Session token override
 
-For CI, headless environments, or shared machines, you can supply the session token explicitly. Resolution order (first match wins):
+For CI, headless environments, or shared machines, you can supply the session token explicitly. Doing so also pins every upload to the browser-session flow, so the account it names is the account that uploads. Resolution order (first match wins):
 
 | Priority | Source | When to use |
 |---|---|---|
@@ -222,7 +224,7 @@ jobs:
 
 ## How it works
 
-1. Resolves a `user_session` cookie from the configured source (flag → env → browser).
+1. Tries a single authenticated upload with the `gh` CLI token; on failure falls back to the browser-session flow below, resolving a `user_session` cookie from the configured source (flag → env → browser).
 2. Fetches the target repository's page to obtain an `uploadToken` from the embedded JS payload.
 3. Requests an S3 upload policy from `/upload/policies/assets`.
 4. Uploads the file directly to S3 using the presigned form fields.
@@ -235,7 +237,7 @@ For the full architecture, see **[documentation/architecture.md](documentation/a
 
 ## Requirements
 
-- A supported browser with an active GitHub session — or a `GH_SESSION_TOKEN` for CI.
+- A supported browser with an active GitHub session — or a `GH_SESSION_TOKEN` for CI. Needed for files other than images and video, and for repositories you cannot push to.
 - Read access to the target repository — write access is not required.
 - A target repository — pass `--repo owner/repo`, or run from a git workspace whose `origin` remote is on GitHub.
 - The `gh` CLI must be installed and authenticated (used for repository ID lookup).
@@ -245,6 +247,7 @@ For the full architecture, see **[documentation/architecture.md](documentation/a
 - Uses an **undocumented** internal GitHub API that may change without notice.
 - `uploadToken` is usually present on repository pages for any user who can view the repo. An invalid or expired session is the case where it is absent.
 - Session cookies are not scoped credentials; they expire when GitHub invalidates the session.
+- Uploads are attributed to the account that authenticated them, so if your browser session and your `gh` login are different accounts, images and video may be attributed differently from other files. Supply a session token explicitly to pin every upload to one account.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,7 @@ A <code>demo-videos</code> skill publishes the <b>README demo reels</b> &mdash; 
 
 ## Authentication
 
-`gh-image` authenticates with your existing GitHub session — **no tokens to provision, no OAuth scopes to configure** for everyday local use. The tool reads the `user_session` cookie from your browser's encrypted cookie store.
-
-Images and video going to a repository you can push to are uploaded with your `gh` CLI token instead, and never touch the browser cookie store. Everything else — other file types, and repositories you cannot push to — uses the session below.
+`gh-image` authenticates with credentials you already have — **nothing to provision, no OAuth scopes to configure**. Images and video going to a repository you can push to are uploaded with your `gh` CLI token; everything else — other file types, and repositories you cannot push to — falls back to your existing GitHub session, read as the `user_session` cookie from your browser's encrypted cookie store.
 
 **Supported browsers:** Chrome · Brave · Chromium · Edge · Firefox · Opera · Safari
 
@@ -166,7 +164,7 @@ On macOS, a Keychain prompt may appear on first use to authorize access to your 
 
 ### Session token override
 
-For CI, headless environments, or shared machines, you can supply the session token explicitly. Doing so also pins every upload to the browser-session flow, so the account it names is the account that uploads. Resolution order (first match wins):
+For CI, headless environments, or shared machines, you can supply the session token explicitly. Resolution order (first match wins):
 
 | Priority | Source | When to use |
 |---|---|---|
@@ -237,7 +235,7 @@ For the full architecture, see **[documentation/architecture.md](documentation/a
 
 ## Requirements
 
-- A supported browser with an active GitHub session — or a `GH_SESSION_TOKEN` for CI. Needed for files other than images and video, and for repositories you cannot push to.
+- A supported browser with an active GitHub session — or a `GH_SESSION_TOKEN` for CI.
 - Read access to the target repository — write access is not required.
 - A target repository — pass `--repo owner/repo`, or run from a git workspace whose `origin` remote is on GitHub.
 - The `gh` CLI must be installed and authenticated (used for repository ID lookup).

--- a/documentation/architecture.md
+++ b/documentation/architecture.md
@@ -137,7 +137,9 @@ func Resolve(owner, name string) (*Info, error)
 
 ### 6. Upload Flow (`internal/upload/`)
 
-Implements the 3-step upload protocol documented in [github-image-upload-flow.md](github-image-upload-flow.md). All GitHub-bound requests use a shared `http.Client` whose cookie jar is built by `cookies.NewGitHubCookieJar`, so `_gh_sess` rotation is handled automatically.
+Two routes sit behind a `Router` (`route.go`). It first tries `BearerClient` (`bearer.go`), a single authenticated request to `uploads.github.com` using the `gh` CLI token, and falls back to the browser-session `Client` for anything the bearer route refuses. Nothing about GitHub's constraints is encoded in the router — it attempts the fast path and lets the server's answer decide — but it remembers each *durable* rejection for the rest of the run, keyed by content type for a `422` and run-wide for a `400`/`401`/`403`/`404`. Transient failures are retried on the next file. The session cookie is resolved lazily, on the first file that actually needs the fallback.
+
+The browser-session `Client` implements the 3-step upload protocol documented in [github-image-upload-flow.md](github-image-upload-flow.md). All its GitHub-bound requests use a shared `http.Client` whose cookie jar is built by `cookies.NewGitHubCookieJar`, so `_gh_sess` rotation is handled automatically.
 
 All GitHub requests are issued through a `*Client` that carries the cookie-jar
 HTTP client plus a `baseURL` (production `https://github.com`); tests point

--- a/documentation/github-image-upload-flow.md
+++ b/documentation/github-image-upload-flow.md
@@ -2,19 +2,50 @@
 
 ## Overview
 
-GitHub does not provide a public API for uploading attachments (images or files like PDFs and zips) to issues/PRs. The web UI uses an internal 3-step flow involving GitHub's servers and S3. This document describes exactly how that flow works, reverse-engineered from HAR captures. The flow is identical for images and other files; only the finalize path and the resulting URL/markdown differ (noted in Step 3 and Final Result).
+GitHub does not provide a public API for uploading attachments (images or files like PDFs and zips) to issues/PRs. Two undocumented routes exist, and this document describes both, reverse-engineered from HAR captures:
 
-Attachments uploaded this way are scoped to the repository's visibility — private repo uploads require authentication to view (unlike GitHub Release assets, which are always public on public repos).
+- A **single request** to `uploads.github.com`, authenticated with a bearer token. Images and video only, and only on repositories the token can push to.
+- The **3-step flow** the web UI uses on drag-and-drop, involving GitHub's servers and S3, authenticated with browser cookies. This serves everything, and is the fallback whenever the single request does not apply. It is identical for images and other files; only the finalize path and the resulting URL/markdown differ (noted in Step 3 and Final Result).
 
-### The bearer alternative
-
-`POST https://uploads.github.com/user-attachments/assets?name=&content_type=&repository_id=` accepts `Authorization: Bearer <gh auth token>` and returns `201 {"url": ...}` in one request, no cookie and no S3 leg. It is also undocumented, and narrower than the flow below in two ways: it serves only images and video (other content types get `422 content_type is not included in the list of allowed content types`), and only repositories the token can push to (others get `404`). A `Content-Type` request header is mandatory — without one the endpoint answers `400 Invalid Content-Type'` before validating anything else. `gh-image` tries this route first and falls back to the flow below.
+Attachments uploaded either way are scoped to the repository's visibility — private repo uploads require authentication to view (unlike GitHub Release assets, which are always public on public repos).
 
 ## Prerequisites
 
-The only browser credential needed is the `user_session` cookie from `github.com`. GitHub also requires the `__Host-user_session_same_site` cookie for CSRF validation on the upload endpoints — this cookie has the same value as `user_session` (just with a stricter SameSite policy), so it can be synthesized from `user_session` rather than read separately. Everything else (CSRF tokens, S3 presigned URLs) is derived during the flow.
+The single request needs an OAuth token with push access to the target repository; `gh auth token` supplies one.
+
+The 3-step flow needs the `user_session` cookie from `github.com`. GitHub also requires the `__Host-user_session_same_site` cookie for CSRF validation on the upload endpoints — this cookie has the same value as `user_session` (just with a stricter SameSite policy), so it can be synthesized from `user_session` rather than read separately. Everything else (CSRF tokens, S3 presigned URLs) is derived during the flow.
+
+## The Single Request
+
+**Request:** `POST https://uploads.github.com/user-attachments/assets`
+
+**Query Parameters:** `name` (filename), `content_type` (MIME type), `repository_id` (numeric repository ID)
+
+**Headers:**
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer {token}` |
+| `Accept` | `application/json` |
+| `Content-Type` | The file's MIME type. **Mandatory** — without it the response is `400 Invalid Content-Type'` before anything else is validated. |
+| `Expect` | `100-continue` (optional). GitHub answers on the headers alone, so a rejected upload never sends its body. |
+
+**Body:** the raw file bytes.
+
+**Response:** `201 Created` with `{"url": "https://github.com/user-attachments/assets/{uuid}"}` — the same URL shape Step 3 of the flow below produces, and the only field returned.
+
+**Rejections:**
+
+| Response | Meaning |
+|---|---|
+| `422` `content_type is not included in the list of allowed content types` | Not an image or video. Use the flow below. |
+| `404` | No push access to `repository_id`, or the parameter is missing. |
+
+Encode the query with a proper URL encoder: an unescaped `+` in a type like `image/svg+xml` arrives as a space and is rejected.
 
 ## The Flow
+
+Used for every file the single request cannot take.
 
 ### Step 0: Obtain the `uploadToken`
 
@@ -187,6 +218,7 @@ embed inline; other files render as a download link:
 
 | Step | Auth Required |
 |---|---|
+| Single request | `Authorization: Bearer {token}` with push access to the repository |
 | 0 (repo page) | `user_session` + `__Host-user_session_same_site` cookies |
 | 1 (upload policy) | `user_session` + `__Host-user_session_same_site` cookies + `uploadToken` as `authenticity_token` |
 | 2 (S3 upload) | None (presigned URL) |
@@ -214,7 +246,7 @@ Each step produces the token needed for the next GitHub-authenticated step. The 
 
 ## Caveats
 
-- This is an undocumented internal API. It could change without notice.
+- Both routes are undocumented internal APIs. Either could change without notice.
 - The `uploadToken` is usually present on repository pages for any user who can view the repo. An invalid or expired `user_session` is the case where it is absent.
 - The `repository_id` must correspond to a repo the user has access to.
 - The presigned S3 policy has an expiration window (observed ~30 minutes).

--- a/documentation/github-image-upload-flow.md
+++ b/documentation/github-image-upload-flow.md
@@ -6,6 +6,10 @@ GitHub does not provide a public API for uploading attachments (images or files 
 
 Attachments uploaded this way are scoped to the repository's visibility — private repo uploads require authentication to view (unlike GitHub Release assets, which are always public on public repos).
 
+### The bearer alternative
+
+`POST https://uploads.github.com/user-attachments/assets?name=&content_type=&repository_id=` accepts `Authorization: Bearer <gh auth token>` and returns `201 {"url": ...}` in one request, no cookie and no S3 leg. It is also undocumented, and narrower than the flow below in two ways: it serves only images and video (other content types get `422 content_type is not included in the list of allowed content types`), and only repositories the token can push to (others get `404`). A `Content-Type` request header is mandatory — without one the endpoint answers `400 Invalid Content-Type'` before validating anything else. `gh-image` tries this route first and falls back to the flow below.
+
 ## Prerequisites
 
 The only browser credential needed is the `user_session` cookie from `github.com`. GitHub also requires the `__Host-user_session_same_site` cookie for CSRF validation on the upload endpoints — this cookie has the same value as `user_session` (just with a stricter SameSite policy), so it can be synthesized from `user_session` rather than read separately. Everything else (CSRF tokens, S3 presigned URLs) is derived during the flow.

--- a/internal/upload/bearer.go
+++ b/internal/upload/bearer.go
@@ -1,0 +1,143 @@
+package upload
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/drogers0/gh-image/internal/httputil"
+)
+
+// bearerUploadURL is GitHub's undocumented single-request attachment endpoint.
+// It accepts a `gh` OAuth token as a bearer credential, but only for images and
+// video, and only on repositories the token can push to. Router treats every
+// other case as a fallback to the browser-session flow.
+const bearerUploadURL = "https://uploads.github.com"
+
+// StatusError reports a non-2xx response from the bearer upload endpoint.
+// Router classifies Code to decide how far a failure generalizes: a 404 is
+// scoped to the token and repository and so holds for the whole run, while a
+// 422 is scoped to one content type.
+type StatusError struct {
+	Code int
+	Body string
+}
+
+func (e *StatusError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("HTTP %d", e.Code)
+	}
+	return fmt.Sprintf("HTTP %d: %s", e.Code, e.Body)
+}
+
+// BearerClient uploads through the bearer endpoint in a single request.
+// baseURL has no trailing slash; production is bearerUploadURL and tests point
+// it at an httptest server.
+type BearerClient struct {
+	http    *http.Client
+	baseURL string
+	token   string
+}
+
+// NewBearerClient creates a client authenticating with a `gh` OAuth token.
+//
+// The transport is built from scratch rather than cloned from
+// http.DefaultTransport: Transport.Clone copies an already-initialized
+// TLSNextProto map, and the bundled HTTP/2 transport reads ExpectContinueTimeout
+// through a back-pointer to the transport it was bound to — the original, not
+// the clone. A clone would therefore ignore the timeout set below whenever
+// anything else in the process had already used the default transport, silently
+// dropping the 100-continue handshake that keeps a rejected upload from sending
+// its body.
+func NewBearerClient(token string) *BearerClient {
+	return &BearerClient{
+		http: &http.Client{
+			Timeout: 120 * time.Second,
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
+				ForceAttemptHTTP2:     true,
+				MaxIdleConns:          100,
+				IdleConnTimeout:       90 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 2 * time.Second,
+			},
+		},
+		baseURL: bearerUploadURL,
+		token:   token,
+	}
+}
+
+// Upload sends the file in one request and returns the asset reference.
+// The response carries only the URL, so the name is the local basename.
+func (c *BearerClient) Upload(repoID int, path string) (*Result, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("file: %w", err)
+	}
+	contentType := detectContentType(path)
+	fileName := filepath.Base(path)
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	query := url.Values{
+		"name":          {fileName},
+		"content_type":  {contentType},
+		"repository_id": {strconv.Itoa(repoID)},
+	}
+	req, err := http.NewRequest("POST", c.baseURL+"/user-attachments/assets?"+query.Encode(), f)
+	if err != nil {
+		return nil, err
+	}
+	// ContentLength is what lets the transport offer Expect: 100-continue, which
+	// keeps a rejected upload from sending the file body at all.
+	req.ContentLength = info.Size()
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Accept", "application/json")
+	// Omitting Content-Type makes the endpoint answer 400 before it looks at
+	// anything else.
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Expect", "100-continue")
+	req.Header.Set("User-Agent", httputil.UserAgent)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, &StatusError{Code: resp.StatusCode, Body: truncate(string(respBody), 200)}
+	}
+
+	var result struct {
+		URL string `json:"url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding upload response: %w", err)
+	}
+	if result.URL == "" {
+		return nil, fmt.Errorf("upload response missing url")
+	}
+
+	return &Result{
+		URL:      result.URL,
+		Name:     fileName,
+		Markdown: renderMarkdown(fileName, result.URL, contentType),
+	}, nil
+}

--- a/internal/upload/bearer_test.go
+++ b/internal/upload/bearer_test.go
@@ -1,0 +1,276 @@
+package upload
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeTempFile creates a file with the given extension and contents.
+func writeTempFile(t *testing.T, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("writing temp file: %v", err)
+	}
+	return path
+}
+
+// bearerAgainst points a client at a test server.
+func bearerAgainst(server *httptest.Server) *BearerClient {
+	c := NewBearerClient("gho_testtoken")
+	c.baseURL = server.URL
+	return c
+}
+
+func TestBearerUpload_Success(t *testing.T) {
+	var gotQuery, gotAuth, gotAccept, gotContentType, gotExpect, gotPath string
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotAuth = r.Header.Get("Authorization")
+		gotAccept = r.Header.Get("Accept")
+		gotContentType = r.Header.Get("Content-Type")
+		gotExpect = r.Header.Get("Expect")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"url":"https://github.com/user-attachments/assets/abc"}`))
+	}))
+	defer server.Close()
+
+	path := writeTempFile(t, "shot.png", "PNGDATA")
+	res, err := bearerAgainst(server).Upload(42, path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if res.URL != "https://github.com/user-attachments/assets/abc" {
+		t.Errorf("URL = %q", res.URL)
+	}
+	if res.Name != "shot.png" {
+		t.Errorf("Name = %q, want shot.png", res.Name)
+	}
+	if want := "![shot.png](https://github.com/user-attachments/assets/abc)"; res.Markdown != want {
+		t.Errorf("Markdown = %q, want %q", res.Markdown, want)
+	}
+	if gotPath != "/user-attachments/assets" {
+		t.Errorf("path = %q", gotPath)
+	}
+	for _, want := range []string{"name=shot.png", "content_type=image%2Fpng", "repository_id=42"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("query %q missing %q", gotQuery, want)
+		}
+	}
+	if gotAuth != "Bearer gho_testtoken" {
+		t.Errorf("Authorization = %q", gotAuth)
+	}
+	if gotAccept != "application/json" {
+		t.Errorf("Accept = %q", gotAccept)
+	}
+	// Without this header the endpoint answers 400 before looking at anything else.
+	if gotContentType != "image/png" {
+		t.Errorf("Content-Type = %q", gotContentType)
+	}
+	if gotExpect != "100-continue" {
+		t.Errorf("Expect = %q", gotExpect)
+	}
+	if string(gotBody) != "PNGDATA" {
+		t.Errorf("body = %q", gotBody)
+	}
+}
+
+// TestBearerUpload_PlusInContentTypeIsEncoded guards the query encoding: sent
+// raw, the "+" in image/svg+xml arrives as a space and the upload is rejected.
+func TestBearerUpload_PlusInContentTypeIsEncoded(t *testing.T) {
+	var gotContentType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotContentType = r.URL.Query().Get("content_type")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"url":"https://github.com/user-attachments/assets/svg"}`))
+	}))
+	defer server.Close()
+
+	path := writeTempFile(t, "diagram.svg", "<svg/>")
+	if _, err := bearerAgainst(server).Upload(1, path); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotContentType != "image/svg+xml" {
+		t.Errorf("content_type = %q, want image/svg+xml", gotContentType)
+	}
+}
+
+func TestBearerUpload_VideoRendersBareURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"url":"https://github.com/user-attachments/assets/vid"}`))
+	}))
+	defer server.Close()
+
+	path := writeTempFile(t, "clip.mp4", "MP4")
+	res, err := bearerAgainst(server).Upload(1, path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Markdown != "https://github.com/user-attachments/assets/vid" {
+		t.Errorf("Markdown = %q, want the bare URL", res.Markdown)
+	}
+}
+
+func TestBearerUpload_StatusErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+		body string
+	}{
+		{"content type refused", http.StatusUnprocessableEntity, `{"errors":[{"field":"content_type"}]}`},
+		{"no push access", http.StatusNotFound, `{"message":"Not Found"}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.code)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			path := writeTempFile(t, "doc.pdf", "PDF")
+			_, err := bearerAgainst(server).Upload(1, path)
+			var status *StatusError
+			if !errors.As(err, &status) {
+				t.Fatalf("error = %v, want *StatusError", err)
+			}
+			if status.Code != tc.code {
+				t.Errorf("Code = %d, want %d", status.Code, tc.code)
+			}
+			if status.Body != tc.body {
+				t.Errorf("Body = %q, want %q", status.Body, tc.body)
+			}
+		})
+	}
+}
+
+// TestBearerUpload_UnusableSuccess covers a 201 we cannot act on. It must not be
+// a *StatusError, since Router treats those as durable answers about the
+// content type or the run, and this is neither.
+func TestBearerUpload_UnusableSuccess(t *testing.T) {
+	for _, body := range []string{`{}`, `{"url":""}`} {
+		t.Run(body, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write([]byte(body))
+			}))
+			defer server.Close()
+
+			path := writeTempFile(t, "shot.png", "PNG")
+			_, err := bearerAgainst(server).Upload(1, path)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			var status *StatusError
+			if errors.As(err, &status) {
+				t.Errorf("error = %v, want a plain error not *StatusError", err)
+			}
+		})
+	}
+}
+
+// TestBearerUpload_RejectionSkipsBody is the empirical basis for attempting the
+// bearer route unconditionally: a rejected upload must not put the file on the
+// wire. Without the 100-continue handshake the server would read all 4 MB before
+// its 422 reached the client.
+func TestBearerUpload_RejectionSkipsBody(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = listener.Close() }()
+
+	// A raw listener rather than httptest: net/http's server would have to read
+	// the request body to serve the handler, which is the very thing under test.
+	bodyBytes := make(chan int64, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			bodyBytes <- -1
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		// Consume the request head, then reject without ever offering 100-continue.
+		reader := bufio.NewReader(conn)
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil || line == "\r\n" {
+				break
+			}
+		}
+		body := `{"errors":[{"field":"content_type"}]}`
+		fmt.Fprintf(conn, "HTTP/1.1 422 Unprocessable Entity\r\nContent-Type: application/json\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s", len(body), body)
+
+		// Anything arriving now is body the client should not have sent.
+		_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		n, _ := io.Copy(io.Discard, reader)
+		bodyBytes <- n
+	}()
+
+	client := NewBearerClient("gho_testtoken")
+	client.baseURL = "http://" + listener.Addr().String()
+
+	path := writeTempFile(t, "big.pdf", strings.Repeat("x", 4<<20))
+	if _, err := client.Upload(1, path); err == nil {
+		t.Fatal("expected a rejection")
+	}
+	if n := <-bodyBytes; n != 0 {
+		t.Errorf("server received %d body bytes, want 0 — the 100-continue short-circuit is not working", n)
+	}
+}
+
+// TestNewBearerClient_Transport guards the construction decision. The
+// short-circuit test above runs over HTTP/1.1 and would still pass if the
+// transport were cloned from http.DefaultTransport, but that clone silently
+// ignores ExpectContinueTimeout over HTTP/2 because the bundled h2 transport
+// reads it through a back-pointer to the transport it was bound to.
+func TestNewBearerClient_Transport(t *testing.T) {
+	transport, ok := NewBearerClient("t").http.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport is %T, want *http.Transport", NewBearerClient("t").http.Transport)
+	}
+	if transport == http.DefaultTransport {
+		t.Fatal("transport is http.DefaultTransport itself")
+	}
+	if len(transport.TLSNextProto) != 0 {
+		t.Errorf("TLSNextProto is populated (%d entries), which means HTTP/2 was bound to another transport", len(transport.TLSNextProto))
+	}
+	if !transport.ForceAttemptHTTP2 {
+		t.Error("ForceAttemptHTTP2 = false")
+	}
+	if transport.ExpectContinueTimeout == 0 {
+		t.Error("ExpectContinueTimeout = 0, so the body would be sent without waiting for a verdict")
+	}
+}
+
+func TestBearerUpload_MissingFile(t *testing.T) {
+	_, err := NewBearerClient("t").Upload(1, filepath.Join(t.TempDir(), "absent.png"))
+	if err == nil || !strings.Contains(err.Error(), "file:") {
+		t.Fatalf("error = %v, want a file error", err)
+	}
+}
+
+func TestStatusError_Message(t *testing.T) {
+	if got := (&StatusError{Code: 404}).Error(); got != "HTTP 404" {
+		t.Errorf("Error() = %q", got)
+	}
+	if got := (&StatusError{Code: 422, Body: "nope"}).Error(); got != "HTTP 422: nope" {
+		t.Errorf("Error() = %q", got)
+	}
+}

--- a/internal/upload/ghtoken.go
+++ b/internal/upload/ghtoken.go
@@ -1,0 +1,34 @@
+package upload
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// tokenRunner runs an external command and returns its stdout. Injected so the
+// gh subprocess boundary is stubbable in tests, matching internal/repo.
+type tokenRunner func(name string, args ...string) ([]byte, error)
+
+func execRun(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).Output()
+}
+
+// GHAuthToken returns the OAuth token the gh CLI would use. gh resolves
+// GH_TOKEN and GITHUB_TOKEN before its stored credentials, so this is the whole
+// token-source policy.
+func GHAuthToken() (string, error) {
+	return ghAuthToken(execRun)
+}
+
+func ghAuthToken(run tokenRunner) (string, error) {
+	out, err := run("gh", "auth", "token")
+	if err != nil {
+		return "", fmt.Errorf("gh auth token: %w", err)
+	}
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		return "", fmt.Errorf("gh auth token returned no token")
+	}
+	return token, nil
+}

--- a/internal/upload/ghtoken_test.go
+++ b/internal/upload/ghtoken_test.go
@@ -1,0 +1,46 @@
+package upload
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestGHAuthToken(t *testing.T) {
+	tests := []struct {
+		name      string
+		out       string
+		runErr    error
+		want      string
+		wantInErr string
+	}{
+		{name: "trims trailing newline", out: "gho_abc123\n", want: "gho_abc123"},
+		{name: "empty output", out: "  \n", wantInErr: "returned no token"},
+		{name: "gh failure", runErr: fmt.Errorf("exit status 1"), wantInErr: "gh auth token: exit status 1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotName string
+			var gotArgs []string
+			token, err := ghAuthToken(func(name string, args ...string) ([]byte, error) {
+				gotName, gotArgs = name, args
+				return []byte(tc.out), tc.runErr
+			})
+			if gotName != "gh" || strings.Join(gotArgs, " ") != "auth token" {
+				t.Errorf("ran %q %v, want gh auth token", gotName, gotArgs)
+			}
+			if tc.wantInErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantInErr) {
+					t.Fatalf("error = %v, want it to contain %q", err, tc.wantInErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if token != tc.want {
+				t.Errorf("token = %q, want %q", token, tc.want)
+			}
+		})
+	}
+}

--- a/internal/upload/route.go
+++ b/internal/upload/route.go
@@ -72,7 +72,7 @@ func (r *Router) Upload(owner, repo string, repoID int, path string) (*Result, e
 	// keychain prompt rather than trailing it.
 	if !r.notified {
 		r.notified = true
-		r.notify(fmt.Sprintf("Note: fast upload unavailable (%s); using browser session.", reason))
+		r.notify(fmt.Sprintf("Note: fast upload unavailable (%s); using browser session.", shortReason(reason)))
 	}
 
 	client, err := r.cookie()
@@ -116,6 +116,18 @@ func (r *Router) remember(contentType string, err error) {
 	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
 		r.disabled = err
 	}
+}
+
+// shortReason trims a rejection down to what belongs on one stderr line. The
+// endpoint's error bodies run to several hundred characters, which is useful
+// when an upload fails outright but is noise when the fallback then succeeds;
+// composeError keeps the full text for that case.
+func shortReason(err error) string {
+	var status *StatusError
+	if errors.As(err, &status) {
+		return fmt.Sprintf("HTTP %d", status.Code)
+	}
+	return err.Error()
 }
 
 // composeError names both routes: the bearer failure is uninterpretable alone,

--- a/internal/upload/route.go
+++ b/internal/upload/route.go
@@ -1,0 +1,129 @@
+package upload
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Router uploads through the bearer endpoint when it can and the
+// browser-session flow when it cannot.
+//
+// Nothing about GitHub's allowlist or permission rule is encoded here: the
+// bearer route is simply attempted, and the server's answer decides. What is
+// remembered is only what that answer scopes to — a rejected content type, or a
+// rejection that holds for the whole run — so a multi-file run never asks the
+// same question twice. Transient failures are deliberately not remembered; the
+// 100-continue handshake makes retrying them nearly free, while memoizing one
+// would push every remaining file onto the cookie route, and its keychain
+// prompt, over a blip.
+type Router struct {
+	newBearer func() (*BearerClient, error) // nil when an explicit session token pins the cookie route
+	newCookie func() (*Client, error)
+	notify    func(string)
+
+	bearer   *BearerClient
+	rejected map[string]error // content type -> why the endpoint refused it
+	disabled error            // non-nil once the bearer route is off for the run
+
+	cookie    *Client
+	cookieErr error
+	notified  bool
+}
+
+// errExplicitSessionToken disables the bearer route when the user named the
+// account to upload as. It reports the source, never the token value.
+var errExplicitSessionToken = errors.New("explicit session token supplied")
+
+func NewRouter(newBearer func() (*BearerClient, error), newCookie func() (*Client, error), notify func(string)) *Router {
+	r := &Router{
+		newBearer: newBearer,
+		newCookie: newCookie,
+		notify:    notify,
+		rejected:  map[string]error{},
+	}
+	if newBearer == nil {
+		r.disabled = errExplicitSessionToken
+	}
+	return r
+}
+
+// Upload returns the asset reference for one file. run() uploads serially, so
+// the memo needs no locking.
+func (r *Router) Upload(owner, repo string, repoID int, path string) (*Result, error) {
+	contentType := detectContentType(path)
+
+	reason := r.disabled
+	if reason == nil {
+		reason = r.rejected[contentType]
+	}
+	if reason == nil {
+		result, err := r.tryBearer(repoID, path)
+		if err == nil {
+			return result, nil
+		}
+		r.remember(contentType, err)
+		reason = err
+	}
+
+	// Announce before resolving the session, so the explanation precedes any
+	// keychain prompt rather than trailing it.
+	if !r.notified {
+		r.notified = true
+		r.notify(fmt.Sprintf("Note: fast upload unavailable (%s); using browser session.", reason))
+	}
+
+	if r.cookie == nil && r.cookieErr == nil {
+		r.cookie, r.cookieErr = r.newCookie()
+	}
+	if r.cookieErr != nil {
+		return nil, composeError(reason, r.cookieErr)
+	}
+
+	// Only client construction is memoized: every file gets its own attempt, so
+	// one flaky upload does not poison the rest of the run.
+	result, err := r.cookie.Upload(owner, repo, repoID, path)
+	if err != nil {
+		return nil, composeError(reason, err)
+	}
+	return result, nil
+}
+
+// tryBearer builds the bearer client on first use and attempts the upload.
+func (r *Router) tryBearer(repoID int, path string) (*Result, error) {
+	if r.bearer == nil {
+		bearer, err := r.newBearer()
+		if err != nil {
+			// gh auth token will not start succeeding mid-run.
+			r.disabled = err
+			return nil, err
+		}
+		r.bearer = bearer
+	}
+	return r.bearer.Upload(repoID, path)
+}
+
+// remember records a failure only when it says something durable. A 422 naming
+// content_type is scoped to that type; 400/401/403/404 hold for the run; a 429,
+// a 5xx, a transport error or an unusable 201 say nothing about the next file.
+func (r *Router) remember(contentType string, err error) {
+	var status *StatusError
+	if !errors.As(err, &status) {
+		return
+	}
+	switch status.Code {
+	case http.StatusUnprocessableEntity:
+		if strings.Contains(status.Body, "content_type") {
+			r.rejected[contentType] = err
+		}
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		r.disabled = err
+	}
+}
+
+// composeError names both routes: the bearer failure is uninterpretable alone,
+// and the cookie failure carries the actionable detail, so it is the one wrapped.
+func composeError(bearerErr, cookieErr error) error {
+	return fmt.Errorf("fast upload failed (%v); browser-session upload failed: %w", bearerErr, cookieErr)
+}

--- a/internal/upload/route.go
+++ b/internal/upload/route.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 )
 
 // Router uploads through the bearer endpoint when it can and the
@@ -19,17 +20,16 @@ import (
 // would push every remaining file onto the cookie route, and its keychain
 // prompt, over a blip.
 type Router struct {
-	newBearer func() (*BearerClient, error) // nil when an explicit session token pins the cookie route
-	newCookie func() (*Client, error)
-	notify    func(string)
+	// Both constructors are memoized, so the gh token is fetched once and the
+	// browser session resolved once, however many files a run holds. Only
+	// construction is memoized: each file still gets its own upload attempt.
+	bearer func() (*BearerClient, error) // nil when an explicit session token pins the cookie route
+	cookie func() (*Client, error)
+	notify func(string)
 
-	bearer   *BearerClient
 	rejected map[string]error // content type -> why the endpoint refused it
 	disabled error            // non-nil once the bearer route is off for the run
-
-	cookie    *Client
-	cookieErr error
-	notified  bool
+	notified bool
 }
 
 // errExplicitSessionToken disables the bearer route when the user named the
@@ -38,13 +38,14 @@ var errExplicitSessionToken = errors.New("explicit session token supplied")
 
 func NewRouter(newBearer func() (*BearerClient, error), newCookie func() (*Client, error), notify func(string)) *Router {
 	r := &Router{
-		newBearer: newBearer,
-		newCookie: newCookie,
-		notify:    notify,
-		rejected:  map[string]error{},
+		cookie:   sync.OnceValues(newCookie),
+		notify:   notify,
+		rejected: map[string]error{},
 	}
 	if newBearer == nil {
 		r.disabled = errExplicitSessionToken
+	} else {
+		r.bearer = sync.OnceValues(newBearer)
 	}
 	return r
 }
@@ -74,16 +75,14 @@ func (r *Router) Upload(owner, repo string, repoID int, path string) (*Result, e
 		r.notify(fmt.Sprintf("Note: fast upload unavailable (%s); using browser session.", reason))
 	}
 
-	if r.cookie == nil && r.cookieErr == nil {
-		r.cookie, r.cookieErr = r.newCookie()
-	}
-	if r.cookieErr != nil {
-		return nil, composeError(reason, r.cookieErr)
+	client, err := r.cookie()
+	if err != nil {
+		return nil, composeError(reason, err)
 	}
 
-	// Only client construction is memoized: every file gets its own attempt, so
-	// one flaky upload does not poison the rest of the run.
-	result, err := r.cookie.Upload(owner, repo, repoID, path)
+	// One flaky upload must not poison the rest of the run, so the per-file
+	// result is never folded back into the memoized construction.
+	result, err := client.Upload(owner, repo, repoID, path)
 	if err != nil {
 		return nil, composeError(reason, err)
 	}
@@ -92,16 +91,13 @@ func (r *Router) Upload(owner, repo string, repoID int, path string) (*Result, e
 
 // tryBearer builds the bearer client on first use and attempts the upload.
 func (r *Router) tryBearer(repoID int, path string) (*Result, error) {
-	if r.bearer == nil {
-		bearer, err := r.newBearer()
-		if err != nil {
-			// gh auth token will not start succeeding mid-run.
-			r.disabled = err
-			return nil, err
-		}
-		r.bearer = bearer
+	client, err := r.bearer()
+	if err != nil {
+		// gh auth token will not start succeeding mid-run.
+		r.disabled = err
+		return nil, err
 	}
-	return r.bearer.Upload(repoID, path)
+	return client.Upload(repoID, path)
 }
 
 // remember records a failure only when it says something durable. A 422 naming

--- a/internal/upload/route_test.go
+++ b/internal/upload/route_test.go
@@ -316,6 +316,25 @@ func TestRouter_NoticePrecedesSessionResolution(t *testing.T) {
 	}
 }
 
+// TestRouter_NoticeOmitsResponseBody keeps the one-line notice readable: the
+// endpoint's rejection bodies run to hundreds of characters, and they belong in
+// the error returned when the fallback also fails, not on a success path.
+func TestRouter_NoticeOmitsResponseBody(t *testing.T) {
+	bearer := newBearerStub(t, refusedContentType)
+	cookie := newCookieStub(t)
+	h := routerFor(t, bearer, cookie)
+
+	if _, err := h.upload(t, writeTempFile(t, "report.pdf", "PDF")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(h.notices) != 1 {
+		t.Fatalf("notices = %v, want one", h.notices)
+	}
+	if want := "Note: fast upload unavailable (HTTP 422); using browser session."; h.notices[0] != want {
+		t.Errorf("notice = %q, want %q", h.notices[0], want)
+	}
+}
+
 // TestRouter_BothRoutesFailNamesBoth covers the diagnosability cost of removing
 // the predicate — including for a file that never attempted the fast path
 // because an earlier file already tripped the memo.

--- a/internal/upload/route_test.go
+++ b/internal/upload/route_test.go
@@ -1,0 +1,382 @@
+package upload
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// bearerStub serves the bearer endpoint, answering each request from responses
+// in order (the last entry repeats), and counts what it received.
+type bearerStub struct {
+	server *httptest.Server
+	calls  atomic.Int32
+}
+
+type bearerReply struct {
+	code int
+	body string
+}
+
+func newBearerStub(t *testing.T, replies ...bearerReply) *bearerStub {
+	t.Helper()
+	stub := &bearerStub{}
+	stub.server = newServer(t, func(w http.ResponseWriter, r *http.Request) {
+		n := int(stub.calls.Add(1)) - 1
+		if n >= len(replies) {
+			n = len(replies) - 1
+		}
+		w.WriteHeader(replies[n].code)
+		_, _ = w.Write([]byte(replies[n].body))
+	})
+	return stub
+}
+
+func (s *bearerStub) client() *BearerClient {
+	c := NewBearerClient("gho_test")
+	c.baseURL = s.server.URL
+	return c
+}
+
+func created(url string) bearerReply {
+	return bearerReply{http.StatusCreated, fmt.Sprintf(`{"url":%q}`, url)}
+}
+
+var refusedContentType = bearerReply{
+	http.StatusUnprocessableEntity,
+	`{"errors":[{"field":"content_type","message":"content_type is not included in the list of allowed content types"}]}`,
+}
+
+// cookieStub serves the full four-step browser-session flow and counts uploads.
+type cookieStub struct {
+	server *httptest.Server
+	calls  atomic.Int32
+	fail   func(call int) bool // when true, the S3 leg fails for that call
+}
+
+func newCookieStub(t *testing.T) *cookieStub {
+	t.Helper()
+	stub := &cookieStub{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/octo/hello", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`x={"uploadToken":"TKN"}`))
+	})
+	mux.HandleFunc("/upload/policies/assets", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(validPolicy(stub.server.URL + "/s3")))
+	})
+	mux.HandleFunc("/s3", func(w http.ResponseWriter, r *http.Request) {
+		call := int(stub.calls.Add(1))
+		if stub.fail != nil && stub.fail(call) {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("/upload/assets/99", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"href":"https://gh/assets/cookie","name":"pic.png"}`))
+	})
+	stub.server = httptest.NewServer(mux)
+	t.Cleanup(stub.server.Close)
+	return stub
+}
+
+// routerFor wires a Router onto the two stubs, recording notices and the order
+// in which the two lazy constructors ran.
+type harness struct {
+	router       *Router
+	notices      []string
+	events       []string
+	bearerBuilds int
+	cookieBuilds int
+}
+
+func routerFor(t *testing.T, bearer *bearerStub, cookie *cookieStub) *harness {
+	t.Helper()
+	h := &harness{}
+	var newBearer func() (*BearerClient, error)
+	if bearer != nil {
+		newBearer = func() (*BearerClient, error) {
+			h.bearerBuilds++
+			return bearer.client(), nil
+		}
+	}
+	h.router = NewRouter(newBearer, func() (*Client, error) {
+		h.cookieBuilds++
+		h.events = append(h.events, "cookie")
+		return &Client{http: cookie.server.Client(), baseURL: cookie.server.URL}, nil
+	}, func(msg string) {
+		h.notices = append(h.notices, msg)
+		h.events = append(h.events, "notify")
+	})
+	return h
+}
+
+func (h *harness) upload(t *testing.T, path string) (*Result, error) {
+	t.Helper()
+	return h.router.Upload("octo", "hello", 42, path)
+}
+
+// TestRouter_BearerSuccessNeverTouchesSession is the lazy-session guarantee: a
+// run that stays on the fast path must not resolve a browser session at all.
+func TestRouter_BearerSuccessNeverTouchesSession(t *testing.T) {
+	bearer := newBearerStub(t, created("https://gh/assets/fast"))
+	cookie := newCookieStub(t)
+	h := routerFor(t, bearer, cookie)
+
+	res, err := h.upload(t, writeTempFile(t, "shot.png", "PNG"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.URL != "https://gh/assets/fast" {
+		t.Errorf("URL = %q, want the bearer asset", res.URL)
+	}
+	if h.cookieBuilds != 0 || cookie.calls.Load() != 0 {
+		t.Errorf("session was resolved (%d builds, %d uploads) on a successful fast path", h.cookieBuilds, cookie.calls.Load())
+	}
+	if len(h.notices) != 0 {
+		t.Errorf("unexpected notice: %v", h.notices)
+	}
+}
+
+// TestRouter_NoPushAccessDisablesRun covers the stable-failure memo: a 404 is
+// scoped to the token and repository, so later files must not retry.
+func TestRouter_NoPushAccessDisablesRun(t *testing.T) {
+	bearer := newBearerStub(t, bearerReply{http.StatusNotFound, `{"message":"Not Found"}`})
+	cookie := newCookieStub(t)
+	h := routerFor(t, bearer, cookie)
+
+	for _, name := range []string{"one.png", "two.png"} {
+		if _, err := h.upload(t, writeTempFile(t, name, "PNG")); err != nil {
+			t.Fatalf("%s: unexpected error: %v", name, err)
+		}
+	}
+	if got := bearer.calls.Load(); got != 1 {
+		t.Errorf("bearer attempted %d times, want 1", got)
+	}
+	if got := cookie.calls.Load(); got != 2 {
+		t.Errorf("cookie uploads = %d, want 2", got)
+	}
+	if h.bearerBuilds != 1 || h.cookieBuilds != 1 {
+		t.Errorf("builds: bearer=%d cookie=%d, want 1 and 1", h.bearerBuilds, h.cookieBuilds)
+	}
+}
+
+// TestRouter_RefusedContentTypeIsScopedToThatType is the reason the memo is
+// keyed by content type: a refused PDF must not cost the PNG its fast path.
+func TestRouter_RefusedContentTypeIsScopedToThatType(t *testing.T) {
+	bearer := newBearerStub(t, refusedContentType, created("https://gh/assets/png"))
+	cookie := newCookieStub(t)
+	h := routerFor(t, bearer, cookie)
+
+	if _, err := h.upload(t, writeTempFile(t, "report.pdf", "PDF")); err != nil {
+		t.Fatalf("pdf: unexpected error: %v", err)
+	}
+	res, err := h.upload(t, writeTempFile(t, "shot.png", "PNG"))
+	if err != nil {
+		t.Fatalf("png: unexpected error: %v", err)
+	}
+	if res.URL != "https://gh/assets/png" {
+		t.Errorf("png took the cookie route (URL = %q)", res.URL)
+	}
+	if got := bearer.calls.Load(); got != 2 {
+		t.Errorf("bearer attempted %d times, want 2", got)
+	}
+	if got := cookie.calls.Load(); got != 1 {
+		t.Errorf("cookie uploads = %d, want 1 (the pdf only)", got)
+	}
+}
+
+func TestRouter_SameContentTypeAskedOnce(t *testing.T) {
+	bearer := newBearerStub(t, refusedContentType)
+	cookie := newCookieStub(t)
+	h := routerFor(t, bearer, cookie)
+
+	for _, name := range []string{"a.pdf", "b.pdf"} {
+		if _, err := h.upload(t, writeTempFile(t, name, "PDF")); err != nil {
+			t.Fatalf("%s: unexpected error: %v", name, err)
+		}
+	}
+	if got := bearer.calls.Load(); got != 1 {
+		t.Errorf("bearer attempted %d times, want 1", got)
+	}
+}
+
+// TestRouter_TransientFailuresAreRetried is the counterpart to the stable memo:
+// a blip says nothing about the next file, so the fast path must survive it.
+func TestRouter_TransientFailuresAreRetried(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		reply bearerReply
+	}{
+		{"server error", bearerReply{http.StatusInternalServerError, `{"message":"oops"}`}},
+		{"rate limited", bearerReply{http.StatusTooManyRequests, `{"message":"slow down"}`}},
+		{"422 unrelated to content type", bearerReply{http.StatusUnprocessableEntity, `{"errors":[{"field":"size"}]}`}},
+		{"unusable success", bearerReply{http.StatusCreated, `{}`}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bearer := newBearerStub(t, tc.reply, created("https://gh/assets/second"))
+			cookie := newCookieStub(t)
+			h := routerFor(t, bearer, cookie)
+
+			if _, err := h.upload(t, writeTempFile(t, "one.png", "PNG")); err != nil {
+				t.Fatalf("first: unexpected error: %v", err)
+			}
+			res, err := h.upload(t, writeTempFile(t, "two.png", "PNG"))
+			if err != nil {
+				t.Fatalf("second: unexpected error: %v", err)
+			}
+			if res.URL != "https://gh/assets/second" {
+				t.Errorf("second file did not retry the fast path (URL = %q)", res.URL)
+			}
+			if got := bearer.calls.Load(); got != 2 {
+				t.Errorf("bearer attempted %d times, want 2", got)
+			}
+		})
+	}
+}
+
+// TestRouter_BearerBuildFailure covers a missing gh token: no attempt is made,
+// nothing panics on a nil client, and gh is not re-invoked per file.
+func TestRouter_BearerBuildFailure(t *testing.T) {
+	bearer := newBearerStub(t, created("https://gh/assets/unused"))
+	cookie := newCookieStub(t)
+	h := routerFor(t, bearer, cookie)
+	builds := 0
+	h.router.newBearer = func() (*BearerClient, error) {
+		builds++
+		return nil, fmt.Errorf("gh auth token: not logged in")
+	}
+
+	for _, name := range []string{"one.png", "two.png"} {
+		if _, err := h.upload(t, writeTempFile(t, name, "PNG")); err != nil {
+			t.Fatalf("%s: unexpected error: %v", name, err)
+		}
+	}
+	if builds != 1 {
+		t.Errorf("gh invoked %d times, want 1", builds)
+	}
+	if got := bearer.calls.Load(); got != 0 {
+		t.Errorf("bearer attempted %d times, want 0", got)
+	}
+	if len(h.notices) != 1 || !strings.Contains(h.notices[0], "not logged in") {
+		t.Errorf("notices = %v, want one naming the gh failure", h.notices)
+	}
+}
+
+// TestRouter_ExplicitSessionTokenPinsCookieRoute covers decision 5: naming the
+// uploading account must not be silently overridden by the gh identity. The
+// notice names the source, never the token value.
+func TestRouter_ExplicitSessionTokenPinsCookieRoute(t *testing.T) {
+	bearer := newBearerStub(t, created("https://gh/assets/unused"))
+	cookie := newCookieStub(t)
+	h := routerFor(t, nil, cookie)
+
+	if _, err := h.upload(t, writeTempFile(t, "shot.png", "PNG")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := bearer.calls.Load(); got != 0 {
+		t.Errorf("bearer attempted %d times, want 0", got)
+	}
+	if len(h.notices) != 1 || !strings.Contains(h.notices[0], "explicit session token supplied") {
+		t.Fatalf("notices = %v, want one naming the explicit session token", h.notices)
+	}
+}
+
+// TestRouter_NoticePrecedesSessionResolution locks the ordering the notice
+// exists for: it must land before the keychain prompt that cookie resolution
+// can trigger, not after it.
+func TestRouter_NoticePrecedesSessionResolution(t *testing.T) {
+	bearer := newBearerStub(t, bearerReply{http.StatusNotFound, `{"message":"Not Found"}`})
+	cookie := newCookieStub(t)
+	h := routerFor(t, bearer, cookie)
+
+	for _, name := range []string{"one.png", "two.png"} {
+		if _, err := h.upload(t, writeTempFile(t, name, "PNG")); err != nil {
+			t.Fatalf("%s: unexpected error: %v", name, err)
+		}
+	}
+	if len(h.events) < 2 || h.events[0] != "notify" || h.events[1] != "cookie" {
+		t.Errorf("events = %v, want notify before cookie", h.events)
+	}
+	if len(h.notices) != 1 {
+		t.Errorf("notice printed %d times, want 1", len(h.notices))
+	}
+	if !strings.Contains(h.notices[0], "HTTP 404") {
+		t.Errorf("notice = %q, want it to name the bearer status", h.notices[0])
+	}
+}
+
+// TestRouter_BothRoutesFailNamesBoth covers the diagnosability cost of removing
+// the predicate — including for a file that never attempted the fast path
+// because an earlier file already tripped the memo.
+func TestRouter_BothRoutesFailNamesBoth(t *testing.T) {
+	bearer := newBearerStub(t, bearerReply{http.StatusNotFound, `{"message":"Not Found"}`})
+	cookie := newCookieStub(t)
+	cookie.fail = func(int) bool { return true }
+	h := routerFor(t, bearer, cookie)
+
+	for i, name := range []string{"one.png", "two.png"} {
+		_, err := h.upload(t, writeTempFile(t, name, "PNG"))
+		if err == nil {
+			t.Fatalf("%s: expected an error", name)
+		}
+		if !strings.Contains(err.Error(), "HTTP 404") {
+			t.Errorf("file %d error %q does not name the fast-path failure", i, err)
+		}
+		if !strings.Contains(err.Error(), "step 2 (S3 upload)") {
+			t.Errorf("file %d error %q does not name the browser-session failure", i, err)
+		}
+	}
+}
+
+// TestRouter_CookieUploadFailureIsNotSticky separates client construction, which
+// is memoized, from a per-file upload failure, which must not be.
+func TestRouter_CookieUploadFailureIsNotSticky(t *testing.T) {
+	bearer := newBearerStub(t, bearerReply{http.StatusNotFound, `{"message":"Not Found"}`})
+	cookie := newCookieStub(t)
+	cookie.fail = func(call int) bool { return call == 1 }
+	h := routerFor(t, bearer, cookie)
+
+	if _, err := h.upload(t, writeTempFile(t, "one.png", "PNG")); err == nil {
+		t.Fatal("first upload: expected an error")
+	}
+	res, err := h.upload(t, writeTempFile(t, "two.png", "PNG"))
+	if err != nil {
+		t.Fatalf("second upload: unexpected error: %v", err)
+	}
+	if res.URL != "https://gh/assets/cookie" {
+		t.Errorf("URL = %q, want the cookie-route asset", res.URL)
+	}
+	if h.cookieBuilds != 1 {
+		t.Errorf("cookie client built %d times, want 1", h.cookieBuilds)
+	}
+}
+
+// TestRouter_CookieBuildFailure covers the memoized construction failure: the
+// session is resolved once, and every file reports both routes.
+func TestRouter_CookieBuildFailure(t *testing.T) {
+	bearer := newBearerStub(t, bearerReply{http.StatusNotFound, `{"message":"Not Found"}`})
+	builds := 0
+	router := NewRouter(
+		func() (*BearerClient, error) { return bearer.client(), nil },
+		func() (*Client, error) {
+			builds++
+			return nil, fmt.Errorf("no session token found")
+		},
+		func(string) {},
+	)
+
+	for _, name := range []string{"one.png", "two.png"} {
+		_, err := router.Upload("octo", "hello", 42, writeTempFile(t, name, "PNG"))
+		if err == nil || !strings.Contains(err.Error(), "no session token found") {
+			t.Fatalf("%s: error = %v, want the session failure", name, err)
+		}
+	}
+	if builds != 1 {
+		t.Errorf("session resolved %d times, want 1", builds)
+	}
+}

--- a/internal/upload/route_test.go
+++ b/internal/upload/route_test.go
@@ -244,15 +244,21 @@ func TestRouter_TransientFailuresAreRetried(t *testing.T) {
 func TestRouter_BearerBuildFailure(t *testing.T) {
 	bearer := newBearerStub(t, created("https://gh/assets/unused"))
 	cookie := newCookieStub(t)
-	h := routerFor(t, bearer, cookie)
 	builds := 0
-	h.router.newBearer = func() (*BearerClient, error) {
-		builds++
-		return nil, fmt.Errorf("gh auth token: not logged in")
-	}
+	var notices []string
+	router := NewRouter(
+		func() (*BearerClient, error) {
+			builds++
+			return nil, fmt.Errorf("gh auth token: not logged in")
+		},
+		func() (*Client, error) {
+			return &Client{http: cookie.server.Client(), baseURL: cookie.server.URL}, nil
+		},
+		func(msg string) { notices = append(notices, msg) },
+	)
 
 	for _, name := range []string{"one.png", "two.png"} {
-		if _, err := h.upload(t, writeTempFile(t, name, "PNG")); err != nil {
+		if _, err := router.Upload("octo", "hello", 42, writeTempFile(t, name, "PNG")); err != nil {
 			t.Fatalf("%s: unexpected error: %v", name, err)
 		}
 	}
@@ -262,8 +268,8 @@ func TestRouter_BearerBuildFailure(t *testing.T) {
 	if got := bearer.calls.Load(); got != 0 {
 		t.Errorf("bearer attempted %d times, want 0", got)
 	}
-	if len(h.notices) != 1 || !strings.Contains(h.notices[0], "not logged in") {
-		t.Errorf("notices = %v, want one naming the gh failure", h.notices)
+	if len(notices) != 1 || !strings.Contains(notices[0], "not logged in") {
+		t.Errorf("notices = %v, want one naming the gh failure", notices)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,9 @@ const usage = `Usage:
 // version is set via -ldflags "-X main.version=..." at release build time.
 var version = "dev"
 
+// sessionTokenEnvVar supplies the user_session cookie value without a flag.
+const sessionTokenEnvVar = "GH_SESSION_TOKEN"
+
 func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, productionDeps()))
 }
@@ -33,12 +36,13 @@ type uploadFunc func(info *repo.Info, path string) (string, error)
 // deps are the I/O boundaries run() depends on; productionDeps wires the real ones,
 // tests inject stubs so the orchestration spine runs without network/subprocess/exit.
 type deps struct {
-	resolveRepo   func(owner, name string) (*repo.Info, error)
-	resolveCookie func(tokenFlag string) (*http.Cookie, error)
-	// newUploader builds an uploader from a session cookie. It is called once per
-	// run so the underlying HTTP client (and its cookie jar) is shared across all
-	// files, matching the single-client behavior of the original implementation.
-	newUploader  func(cookie *http.Cookie) uploadFunc
+	resolveRepo func(owner, name string) (*repo.Info, error)
+	// newUploader builds an uploader for the run. It is called once so both the
+	// bearer client and the session-cookie client (and its cookie jar) are shared
+	// across all files. The session is resolved lazily, on the first file that
+	// needs the browser-session flow, so runs that stay on the fast path never
+	// touch the browser's cookie store.
+	newUploader  func(tokenFlag string, stderr io.Writer) uploadFunc
 	extractToken func() (string, error)
 	checkToken   func(tokenFlag string) (username, source string, err error)
 }
@@ -46,14 +50,33 @@ type deps struct {
 func productionDeps() deps {
 	return deps{
 		resolveRepo: repo.Resolve,
-		resolveCookie: func(tokenFlag string) (*http.Cookie, error) {
-			cookie, _, err := resolveSessionCookie(tokenFlag)
-			return cookie, err
-		},
-		newUploader: func(cookie *http.Cookie) uploadFunc {
-			client := upload.NewClient(cookie)
+		newUploader: func(tokenFlag string, stderr io.Writer) uploadFunc {
+			// An explicitly supplied session token names the account that uploads;
+			// the bearer route authenticates as whoever gh is, so honoring that
+			// choice means staying on the cookie route for every file.
+			var newBearer func() (*upload.BearerClient, error)
+			if tokenFlag == "" && os.Getenv(sessionTokenEnvVar) == "" {
+				newBearer = func() (*upload.BearerClient, error) {
+					token, err := upload.GHAuthToken()
+					if err != nil {
+						return nil, err
+					}
+					return upload.NewBearerClient(token), nil
+				}
+			}
+			router := upload.NewRouter(
+				newBearer,
+				func() (*upload.Client, error) {
+					cookie, _, err := resolveSessionCookie(tokenFlag)
+					if err != nil {
+						return nil, err
+					}
+					return upload.NewClient(cookie), nil
+				},
+				func(msg string) { fmt.Fprintln(stderr, msg) },
+			)
 			return func(info *repo.Info, path string) (string, error) {
-				res, err := client.Upload(info.Owner, info.Name, info.ID, path)
+				res, err := router.Upload(info.Owner, info.Name, info.ID, path)
 				if err != nil {
 					return "", err
 				}
@@ -245,15 +268,10 @@ func run(args []string, stdout, stderr io.Writer, d deps) int {
 		return 1
 	}
 
-	// Get session cookie (flag > env var > browser)
-	cookie, err := d.resolveCookie(tokenFlag)
-	if err != nil {
-		fmt.Fprintf(stderr, "Error: %v\n", err)
-		return 1
-	}
-
-	// Build the uploader once so its HTTP client/cookie jar is shared across files.
-	uploadFile := d.newUploader(cookie)
+	// Build the uploader once so its HTTP clients are shared across files. The
+	// session cookie behind it is resolved only if a file needs the
+	// browser-session flow.
+	uploadFile := d.newUploader(tokenFlag, stderr)
 
 	// Upload each file, continuing on error
 	hasError := false
@@ -319,7 +337,7 @@ func resolveSessionCookie(tokenFlag string) (*http.Cookie, string, error) {
 			return err
 		})
 	}
-	return resolveSessionCookieWithGetter(tokenFlag, os.Getenv("GH_SESSION_TOKEN"), get)
+	return resolveSessionCookieWithGetter(tokenFlag, os.Getenv(sessionTokenEnvVar), get)
 }
 
 // resolveSessionCookieWithGetter is a testable variant of resolveSessionCookie

--- a/main.go
+++ b/main.go
@@ -51,11 +51,8 @@ func productionDeps() deps {
 	return deps{
 		resolveRepo: repo.Resolve,
 		newUploader: func(tokenFlag string, stderr io.Writer) uploadFunc {
-			// An explicitly supplied session token names the account that uploads;
-			// the bearer route authenticates as whoever gh is, so honoring that
-			// choice means staying on the cookie route for every file.
 			var newBearer func() (*upload.BearerClient, error)
-			if tokenFlag == "" && os.Getenv(sessionTokenEnvVar) == "" {
+			if useBearerRoute(tokenFlag, os.Getenv(sessionTokenEnvVar)) {
 				newBearer = func() (*upload.BearerClient, error) {
 					token, err := upload.GHAuthToken()
 					if err != nil {
@@ -338,6 +335,16 @@ func resolveSessionCookie(tokenFlag string) (*http.Cookie, string, error) {
 		})
 	}
 	return resolveSessionCookieWithGetter(tokenFlag, os.Getenv(sessionTokenEnvVar), get)
+}
+
+// useBearerRoute reports whether uploads may take the gh-token fast path.
+// An explicitly supplied session token names the account that uploads, and the
+// bearer route authenticates as whoever gh is, so honoring that choice means
+// staying on the browser-session flow for every file. The inputs mirror
+// resolveSessionCookieWithGetter's first two, so the two decisions read from
+// the same sources.
+func useBearerRoute(tokenFlag, envToken string) bool {
+	return tokenFlag == "" && envToken == ""
 }
 
 // resolveSessionCookieWithGetter is a testable variant of resolveSessionCookie

--- a/main_test.go
+++ b/main_test.go
@@ -519,6 +519,29 @@ func TestResolveSessionCookie_NilGetter(t *testing.T) {
 	}
 }
 
+// TestUseBearerRoute covers the rule that keeps an explicitly named account
+// from being silently overridden by the gh identity.
+func TestUseBearerRoute(t *testing.T) {
+	tests := []struct {
+		name      string
+		tokenFlag string
+		envToken  string
+		want      bool
+	}{
+		{"no session token supplied", "", "", true},
+		{"--token flag pins the session flow", "tok", "", false},
+		{"GH_SESSION_TOKEN pins the session flow", "", "envtok", false},
+		{"both supplied", "tok", "envtok", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := useBearerRoute(tc.tokenFlag, tc.envToken); got != tc.want {
+				t.Errorf("useBearerRoute(%q, %q) = %v, want %v", tc.tokenFlag, tc.envToken, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestProductionDeps_WiringComplete(t *testing.T) {
 	d := productionDeps()
 	if d.resolveRepo == nil || d.newUploader == nil || d.extractToken == nil || d.checkToken == nil {

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -19,10 +20,7 @@ func okDeps() deps {
 		resolveRepo: func(owner, name string) (*repo.Info, error) {
 			return &repo.Info{Owner: "octo", Name: "hello", ID: 1}, nil
 		},
-		resolveCookie: func(tokenFlag string) (*http.Cookie, error) {
-			return &http.Cookie{Name: "user_session", Value: "tok"}, nil
-		},
-		newUploader: func(cookie *http.Cookie) uploadFunc {
+		newUploader: func(tokenFlag string, stderr io.Writer) uploadFunc {
 			// The stub returns image-embed markdown for any path; run()'s job is the
 			// orchestration spine, not the embed-vs-link decision (that lives in
 			// upload.renderMarkdown and is covered by TestRenderMarkdown).
@@ -394,7 +392,7 @@ func TestRun_Upload(t *testing.T) {
 	})
 	t.Run("partial failure exits 1 but prints successes", func(t *testing.T) {
 		d := okDeps()
-		d.newUploader = func(c *http.Cookie) uploadFunc {
+		d.newUploader = func(string, io.Writer) uploadFunc {
 			return func(info *repo.Info, p string) (string, error) {
 				if p == "bad.png" {
 					return "", fmt.Errorf("upload failed")
@@ -421,12 +419,41 @@ func TestRun_Upload(t *testing.T) {
 			t.Fatalf("code=%d stderr=%q", code, errOut)
 		}
 	})
-	t.Run("resolveCookie error exits 1", func(t *testing.T) {
+	// Session resolution is now lazy, so a missing session surfaces per file
+	// through the upload path rather than as a pre-flight error.
+	t.Run("session resolution failure exits 1", func(t *testing.T) {
 		d := okDeps()
-		d.resolveCookie = func(string) (*http.Cookie, error) { return nil, fmt.Errorf("no token") }
+		d.newUploader = func(string, io.Writer) uploadFunc {
+			return func(*repo.Info, string) (string, error) { return "", fmt.Errorf("no token") }
+		}
 		code, _, errOut := runWith(t, []string{"a.png"}, d)
-		if code != 1 || !strings.Contains(errOut, "Error:") {
+		if code != 1 || !strings.Contains(errOut, "Error uploading a.png: no token") {
 			t.Fatalf("code=%d stderr=%q", code, errOut)
+		}
+	})
+	t.Run("fallback notice goes to stderr only, once per run", func(t *testing.T) {
+		d := okDeps()
+		d.newUploader = func(tokenFlag string, stderr io.Writer) uploadFunc {
+			notified := false
+			return func(info *repo.Info, p string) (string, error) {
+				if !notified {
+					notified = true
+					fmt.Fprintln(stderr, "Note: fast upload unavailable (HTTP 404); using browser session.")
+				}
+				return "![" + p + "](url)", nil
+			}
+		}
+		code, out, errOut := runWith(t, []string{"a.png", "b.png"}, d)
+		if code != 0 {
+			t.Fatalf("code = %d, want 0", code)
+		}
+		// stdout is piped straight into `gh issue comment`, so it must carry
+		// markdown and nothing else.
+		if strings.Contains(out, "Note:") {
+			t.Errorf("notice leaked into stdout: %q", out)
+		}
+		if n := strings.Count(errOut, "Note: fast upload unavailable"); n != 1 {
+			t.Errorf("notice printed %d times, want 1: %q", n, errOut)
 		}
 	})
 	t.Run("explicit --repo is parsed and passed to resolveRepo", func(t *testing.T) {
@@ -494,7 +521,7 @@ func TestResolveSessionCookie_NilGetter(t *testing.T) {
 
 func TestProductionDeps_WiringComplete(t *testing.T) {
 	d := productionDeps()
-	if d.resolveRepo == nil || d.resolveCookie == nil || d.newUploader == nil || d.extractToken == nil || d.checkToken == nil {
+	if d.resolveRepo == nil || d.newUploader == nil || d.extractToken == nil || d.checkToken == nil {
 		t.Fatal("productionDeps left a boundary unwired")
 	}
 }

--- a/skills/github-image-upload/SKILL.md
+++ b/skills/github-image-upload/SKILL.md
@@ -52,10 +52,11 @@ Check these first. Report failures — do not install or authenticate for the us
    drogers0/gh-image`. Older → the user runs `gh extension upgrade gh-image`. `dev` →
    a local build, warn and continue. Never run install or upgrade yourself.
 
-3. A session credential. That endpoint rejects `gh` tokens; `gh-image` needs the
-   `user_session` cookie, from `GH_SESSION_TOKEN` (CI / headless) or a logged-in
-   browser (Chrome/Brave/Chromium/Edge/Firefox/Opera/Safari — the local default;
-   macOS may prompt for Keychain access, click **Always Allow**).
+3. A session credential, needed for files other than images and video, and for
+   repositories you cannot push to (everything else uploads with the `gh` token).
+   It is the `user_session` cookie, from `GH_SESSION_TOKEN` (CI / headless) or a
+   logged-in browser (Chrome/Brave/Chromium/Edge/Firefox/Opera/Safari — the local
+   default; macOS may prompt for Keychain access, click **Always Allow**).
 
    That cookie grants **full account access** — it is not scoped like a PAT, and
    GitHub offers nothing narrower for this endpoint. Never print, log, or store its


### PR DESCRIPTION
> [!IMPORTANT]
> **Uploads may change identity after this ships.** Attachments are attributed to the account that authenticated them. The browser-session flow uploads as your browser's account; the new fast path uploads as whoever `gh auth login` used. If those differ — a work browser and a personal `gh`, say — images and video will silently start being attributed to the `gh` account while other file types stay on the browser account.
>
> Nothing prompts or warns at upload time, because the fast path succeeding is the quiet path. Supply `--token` or `GH_SESSION_TOKEN` to pin every upload to one account. This belongs in the release notes.

Closes #48.

GitHub's `uploads.github.com/user-attachments/assets` endpoint accepts a `gh` CLI token as a bearer credential and returns an attachment URL in a single request — no session cookie, no S3 leg (RECENTLY CHANGED). Verified live: it serves images and video only (`422` otherwise) and only repositories the token can push to (`404` otherwise), so it is a fast path rather than a replacement.

**The payoff is the lazy session.** The cookie is now resolved on the first file that actually needs it, so the common case — a screenshot into your own repo — never reads the browser cookie store: no keychain prompt, no ABE failure, no expired-session path, and one HTTP request instead of four.

## Approach

Rather than predicting which files qualify, `Router` attempts the fast path and lets the server decide. That keeps GitHub as the only authority on an undocumented endpoint: if the allowlist widens, gh-image gains support with no code change; if the endpoint is withdrawn, uploads keep working through the fallback.

`Expect: 100-continue` makes the doomed attempt cheap — GitHub answers on the header alone, so a rejected upload sends **zero body bytes** (measured: an 8 MB file rejected in ~0.5s with nothing on the wire). The transport is built fresh rather than cloned from `http.DefaultTransport`, because a clone silently ignores `ExpectContinueTimeout` over HTTP/2.

Durable rejections are remembered for the rest of the run so a multi-file run never asks twice — keyed by content type for a `422`, run-wide for `400`/`401`/`403`/`404`. Transient failures (`429`, `5xx`, transport errors) are deliberately not remembered; memoizing a blip would push every remaining file onto the cookie route over a condition that may already have cleared.

An explicit `--token` or `GH_SESSION_TOKEN` disables the fast path entirely. That input names the account that uploads, and CI exports `GITHUB_TOKEN` automatically, so leaving it unguarded would split attribution mid-run.

When both routes fail, the error names both — the fast path's bare `404` is uninterpretable alone, and the session flow's specific errors carry the actionable detail.

## Verified against live GitHub

| Scenario | Result |
|---|---|
| Image → push-access repo | fast path, no notice, no session resolved |
| PDF → same repo | falls back, `/user-attachments/files/` link |
| Image → `cli/cli` (no push) | `HTTP 404`, falls back, works |
| `report.pdf screenshot.png` in one run | PDF falls back, PNG keeps the fast path, notice printed once |
| `GH_SESSION_TOKEN` set | no bearer attempt; both routes named on failure |

## Tests

Real `httptest` servers on both routes, plus a raw `net.Listen` server for the 100-continue assertion — that one fails with 335 KB received if the `Expect` header is dropped, so the optimization cannot silently vanish. A structural check on the transport guards the clone regression, which HTTP/1.1 tests cannot catch.

Coverage in `internal/upload` is 91.4%. `gofmt`, `go vet`, `go test -race`, `golangci-lint` v2.12.2, and the Android cross-build all pass.

## Docs

Accuracy-only edits. Notably `skills/github-image-upload/SKILL.md` claimed "That endpoint rejects `gh` tokens", which this change makes false.
